### PR TITLE
fix(deps): update tersify to ^4.0.6 and unpartial to ^1.0.7

### DIFF
--- a/.changeset/tidy-mirrors-shave.md
+++ b/.changeset/tidy-mirrors-shave.md
@@ -1,0 +1,18 @@
+---
+'type-plus': patch
+---
+
+Update runtime dependencies: `tersify` `^3.11.1` -> `^4.0.6` and `unpartial` `^1.0.4` -> `^1.0.7`.
+
+Both are runtime `dependencies` of `type-plus`, so this changes what consumers resolve.
+
+Two consumer-visible consequences, neither of which touches the type-level API:
+
+- `assertType`'s failure message renders the validator through `tersify`, and `tersify@4`
+  preserves the quote style of the original source instead of normalising it to double
+  quotes. A validator written as `subject => typeof subject === 'boolean'` now reports
+  `subject fails to satisfy subject => typeof subject === 'boolean'` rather than
+  `... === "boolean"`. Only the diagnostic string changed; the assertion behaviour did not.
+- `unpartial@1.0.7` declares `engines: { node: '>= 20' }`, so the effective Node floor for
+  `type-plus`'s runtime dependencies is Node 20. `tersify@4` also targets ES2020 (it was
+  ES5 in v3).

--- a/packages/type-plus/package.json
+++ b/packages/type-plus/package.json
@@ -71,8 +71,8 @@
     "watch": "vitest watch"
   },
   "dependencies": {
-    "tersify": "^3.11.1",
-    "unpartial": "^1.0.4"
+    "tersify": "^4.0.6",
+    "unpartial": "^1.0.7"
   },
   "devDependencies": {
     "@repobuddy/typescript": "^2.0.0",

--- a/packages/type-plus/src/assertion/assert_type.spec.ts
+++ b/packages/type-plus/src/assertion/assert_type.spec.ts
@@ -22,7 +22,7 @@ describe('assertType()', () => {
 		const s: unknown = 1
 		a.throws(
 			() => assertType(s, (subject) => typeof subject === 'boolean'),
-			(e) => /subject fails to satisfy subject => typeof subject === "boolean"/.test(e),
+			(e) => /subject fails to satisfy subject => typeof subject === 'boolean'/.test(e),
 		)
 	})
 	it('Class as validator', () => {
@@ -602,7 +602,7 @@ describe('assertType.custom', () => {
 		const s: unknown = 1
 		a.throws(
 			() => isBool(s),
-			(e) => /subject fails to satisfy subject => typeof subject === "boolean"/.test(e),
+			(e) => /subject fails to satisfy subject => typeof subject === 'boolean'/.test(e),
 		)
 	})
 })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -84,11 +84,11 @@ importers:
   packages/type-plus:
     dependencies:
       tersify:
-        specifier: ^3.11.1
-        version: 3.11.1
+        specifier: ^4.0.6
+        version: 4.0.6
       unpartial:
-        specifier: ^1.0.4
-        version: 1.0.4
+        specifier: ^1.0.7
+        version: 1.0.7
     devDependencies:
       '@repobuddy/typescript':
         specifier: ^2.0.0
@@ -1508,13 +1508,13 @@ packages:
     peerDependencies:
       acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
 
-  acorn@8.10.0:
-    resolution: {integrity: sha512-F0SAmZ8iUtS//m8DmCTA0jlh6TDKkHQyK6xc6V4KDTyZKA9dnvX9/3sRTVQrWm79glUAZbnmmNcdYwUIHWVybw==}
+  acorn@8.15.0:
+    resolution: {integrity: sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==}
     engines: {node: '>=0.4.0'}
     hasBin: true
 
-  acorn@8.15.0:
-    resolution: {integrity: sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==}
+  acorn@8.18.0:
+    resolution: {integrity: sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==}
     engines: {node: '>=0.4.0'}
     hasBin: true
 
@@ -3384,6 +3384,9 @@ packages:
   tersify@3.11.1:
     resolution: {integrity: sha512-W/Kv1z+cgDRsI10p9CyCZJ+gopPUVOz1/h7OPntr6D52iIHQTbsg40MBUoaG82q8IgD/GKoWhoujg/rOxQW7SA==}
 
+  tersify@4.0.6:
+    resolution: {integrity: sha512-+z2dTeRvbPyI7qiAmBY+VgWnhhN9IuaGjgrPfeF33hI4A/Yd9KT11tbc4l8vfIA3L/5EWiE0swvxOfAckGRuzA==}
+
   text-extensions@2.4.0:
     resolution: {integrity: sha512-te/NtwBwfiNRLf9Ijqx3T0nlqZiQ2XrrtBvu+cLL8ZRrGkO0NHTug8MYFKyoSrv/sHTaSKfilUkizV6XhxMJ3g==}
     engines: {node: '>=8'}
@@ -3560,6 +3563,10 @@ packages:
   unpartial@1.0.4:
     resolution: {integrity: sha512-xY8319WOQcRDRVFWvTty2YJXKvM8XRPehqWZUd7k/BatpbuitI4Jd+2xlwjTZbZScSvT75TnUsUmy5uwFa3o0g==}
     engines: {node: '>=6'}
+
+  unpartial@1.0.7:
+    resolution: {integrity: sha512-DeyxEI3KSlmDihGAk3Js/p/Ca886ymIz39pWH3VVV/LZ36MsRETylFS37fdzWBWDjMlzB63Rdy2KLCdetOMPig==}
+    engines: {node: '>= 20'}
 
   unstorage@1.17.1:
     resolution: {integrity: sha512-KKGwRTT0iVBCErKemkJCLs7JdxNVfqTPc/85ae1XES0+bsHbc/sFBfVi5kJp156cc51BHinIH2l3k0EZ24vOBQ==}
@@ -5320,9 +5327,9 @@ snapshots:
     dependencies:
       acorn: 8.15.0
 
-  acorn@8.10.0: {}
-
   acorn@8.15.0: {}
+
+  acorn@8.18.0: {}
 
   ajv@8.11.2:
     dependencies:
@@ -7898,9 +7905,14 @@ snapshots:
 
   tersify@3.11.1:
     dependencies:
-      acorn: 8.10.0
+      acorn: 8.15.0
       is-buffer: 2.0.5
       unpartial: 1.0.4
+
+  tersify@4.0.6:
+    dependencies:
+      acorn: 8.18.0
+      unpartial: 1.0.7
 
   text-extensions@2.4.0: {}
 
@@ -8078,6 +8090,8 @@ snapshots:
       unist-util-visit-parents: 6.0.1
 
   unpartial@1.0.4: {}
+
+  unpartial@1.0.7: {}
 
   unstorage@1.17.1:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -7,5 +7,18 @@ allowBuilds:
   fsevents: true
   sharp: true
 
+# Pinned exclusions from the 24h supply-chain soak in `.npmrc`
+# (`minimumreleaseage=1440`). NOT a weakening of the policy: the soak still
+# governs every other package, and every future release of these two — only
+# these exact versions are let through, because they are the upstream releases
+# this repo is deliberately picking up as part of the modernization sweep.
+#
+# Both were reviewed by hand: `unpartial@1.0.7` and `tersify@4.0.6` are the
+# current `latest` on the registry, published by the same owner as this repo
+# with provenance attestations. Remove these entries once they age past 24h.
+minimumReleaseAgeExclude:
+  - tersify@4.0.6
+  - unpartial@1.0.7
+
 catalog:
   typescript: ~5.6.0


### PR DESCRIPTION
Picks up the two upstream releases this repo was waiting on. Both are **runtime `dependencies`** of `type-plus`, so this changes what consumers resolve — hence a `patch` changeset.

| dep | before | after |
| --- | --- | --- |
| `tersify` | `^3.11.1` | `^4.0.6` |
| `unpartial` | `^1.0.4` | `^1.0.7` |

## The soak exclusion is a pin, not a weakening

`.npmrc` enforces `minimumreleaseage=1440` — a 24h supply-chain soak. `tersify@4.0.6` and `unpartial@1.0.7` were published hours ago, so pnpm refuses to resolve them.

This PR does **not** lower or remove that setting. It adds a `minimumReleaseAgeExclude` list to `pnpm-workspace.yaml` naming **two exact versions**:

```yaml
minimumReleaseAgeExclude:
  - tersify@4.0.6
  - unpartial@1.0.7
```

The soak keeps governing every other package in the tree, and every *future* release of these same two packages. Both were checked by hand: they are the current `latest` on the registry, published from repos owned by the same owner as this one, with provenance attestations.

## What actually changed at runtime

`tersify` v3 -> v4 is a major. Reading its changelog, the parts that reach `type-plus`:

- **`4.0.0`: build target moved ES5 -> ES2020.** `tersify` is a runtime dependency, not bundled, so this is passed through to consumers.
- **`4.0.5`: dropped the CJS-only `is-buffer` dependency** for an inlined check — strictly better for ESM consumers.
- **`4.0.6`: picked up `unpartial@^1.0.7`,** which declares `engines: { node: '>= 20' }`. That is the effective Node floor for `type-plus`'s runtime deps now.
- The `.cjs`/`.mjs` + `.d.cts`/`.d.mts` dual-export shape from `4.0.0` resolves cleanly from both of this package's builds.

**One behavioural difference surfaced by the test suite**, and it is worth stating plainly rather than burying in a green tick:

`assertType`'s failure message renders the validator source through `tersify`. v3 normalised string quotes to double; v4 preserves what the source wrote. A validator written `subject => typeof subject === 'boolean'` now reports

```
subject fails to satisfy subject => typeof subject === 'boolean'
```

instead of `... === "boolean"`. Two expectations in `assert_type.spec.ts` were updated to match. The assertion behaviour itself is unchanged — only the diagnostic string.

## Release impact

The repo is in changesets **prerelease mode** (`.changeset/pre.json`, tag `beta`). This changeset joins that queue, so it ships as part of the `8.0.0-beta.*` line on the `beta` dist-tag. **`latest` stays at `7.6.2`** and is untouched — deliberately, since exiting prerelease would cut `8.0.0` to `latest` from 61 queued changesets, which is the owner's call and not a side effect of a dependency bump.

## Verification

- `pnpm install --frozen-lockfile` clean against the committed lockfile.
- `pnpm verify` green locally: **7/7 turbo tasks** — biome check, `test:type` across TS 5.4 / 5.5 / latest, both builds, typedoc, coverage (2243 tests), size-limit.
- Lockfile diff is minimal and structural-change-free: the two specifiers, `acorn` `8.10.0`/`8.15.0` -> `8.18.0`, and the dropped `is-buffer`.