### PR TITLE
fix(build): emit cjs/package.json type marker so require() resolves

### DIFF
--- a/.changeset/hungry-badgers-repair.md
+++ b/.changeset/hungry-badgers-repair.md
@@ -1,0 +1,15 @@
+---
+'type-plus': patch
+---
+
+Ship a `cjs/package.json` marker so `require('type-plus')` works again.
+
+The package root declares `"type": "module"`, so Node treated the CommonJS
+output in `cjs/` as ESM. `cjs/index.js` then resolved its own `require()`
+calls against the caller instead of against the package, and every CJS
+consumer failed with `Cannot find module './array/array_plus.js'`.
+
+The build now writes `cjs/package.json` (`{"type":"commonjs"}`) and, for
+symmetry, `esm/package.json` (`{"type":"module"}`) after each compile. The
+7.x build emitted the CJS marker via `buddy ts build cjs`; moving to a plain
+`tsc` emit dropped it.

--- a/packages/type-plus/package.json
+++ b/packages/type-plus/package.json
@@ -52,8 +52,8 @@
   ],
   "scripts": {
     "build": "run-p build:*",
-    "build:cjs": "tsc -p tsconfig.cjs.json",
-    "build:esm": "tsc -p tsconfig.esm.json",
+    "build:cjs": "tsc -p tsconfig.cjs.json && node scripts/emit-module-type-marker.mjs cjs commonjs",
+    "build:esm": "tsc -p tsconfig.esm.json && node scripts/emit-module-type-marker.mjs esm module",
     "clean": "rimraf cjs coverage esm lib libm tslib --glob *.tsbuildinfo",
     "coverage": "vitest run --coverage",
     "knip": "knip",

--- a/packages/type-plus/scripts/emit-module-type-marker.mjs
+++ b/packages/type-plus/scripts/emit-module-type-marker.mjs
@@ -1,0 +1,22 @@
+// Usage: node scripts/emit-module-type-marker.mjs <outDir> <commonjs|module>
+//
+// The package root declares `"type": "module"`, so every `.js` file under it is
+// ESM by default -- including the CommonJS output in `cjs/`. Node then loads
+// `cjs/index.js` as ESM, and its `require()` calls resolve against the caller
+// instead of against the package, failing with MODULE_NOT_FOUND.
+//
+// A nearest-parent `package.json` in each output directory tells Node which
+// module system that directory uses. `tsc` does not emit one, and `clean` wipes
+// the directories, so it is written after each compile rather than checked in.
+import { writeFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const [outDir, type] = process.argv.slice(2)
+if (!outDir || (type !== 'commonjs' && type !== 'module')) {
+	console.error('usage: emit-module-type-marker.mjs <outDir> <commonjs|module>')
+	process.exit(1)
+}
+
+const target = join(dirname(fileURLToPath(import.meta.url)), '..', outDir, 'package.json')
+writeFileSync(target, `${JSON.stringify({ type }, null, 2)}\n`)

--- a/turbo.json
+++ b/turbo.json
@@ -6,6 +6,7 @@
 			"inputs": [
 				"src/",
 				"!src/**/*.{spec,test,unit,accept,integrate,system,perf,stress,stories}.{ts,tsx}",
+				"scripts/",
 				"tsconfig*.json"
 			],
 			"outputs": ["lib/**", "cjs/**", "esm/**", "dist/**"]


### PR DESCRIPTION
## The bug

`require('type-plus')` throws on every 8.x beta:

```
Error: Cannot find module './array/array_plus.js'
Require stack:
- <caller>/[eval]
```

Reproduced on Node v26.7.0 against the published `type-plus@8.0.0-beta.9`. This also breaks the published `@unional/gizmo@2.3.3` and `@unional/async-context@9.0.15` (both take `type-plus` as a runtime dependency), and is the cause of cyberuni/async-fp#366.

## Root cause

The package root declares `"type": "module"`. The CommonJS output in `cjs/` has no nearest-parent `package.json`, so it inherits `"type": "module"` and Node loads `cjs/index.js` as ESM. Its internal `require()` calls then resolve relative to the **caller's** directory rather than the package directory, so a file that is present and correct reports MODULE_NOT_FOUND.

This is a regression from 7.x. The published `7.6.2` tarball does ship `cjs/package.json` with `{"type":"commonjs"}` — the 7.x build produced it via `buddy ts build cjs`. The 8.x toolchain moved to a plain `tsc -p tsconfig.cjs.json`, which emits no such marker.

## The fix

`scripts/emit-module-type-marker.mjs` writes the nearest-parent marker after each compile:

- `build:cjs` → `cjs/package.json` = `{"type":"commonjs"}`
- `build:esm` → `esm/package.json` = `{"type":"module"}`

The ESM marker is symmetry/insurance; ESM already worked because it matches the root `type`. `files` already includes `cjs` and `esm`, so both markers ship. `turbo.json` gains `scripts/` as a `build` input so the cache invalidates when the script changes.

## Verification

Built locally, `npm pack`ed, installed the tarball into a scratch project:

```
package/cjs/package.json   ✓ in tarball
package/esm/package.json   ✓ in tarball

node -e "require('type-plus')"                    → cjs ok 54
node --input-type=module -e "import 'type-plus'"  → esm ok 54
```

`attw` on the tarball: **No problems found** — node10, node16-from-CJS (CJS), node16-from-ESM (ESM) and bundler all resolve the correct `types`.

Patch changeset included; on the `beta` prerelease line this produces `8.0.0-beta.10`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014RLRX3QtRpgCfDt16KShQC