### PR TITLE
fix(ci): pin pnpm to 11.1.3 so OIDC trusted publishing works

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,5 +42,5 @@
 		"typescript": "catalog:",
 		"vitest": "^4.0.15"
 	},
-	"packageManager": "pnpm@11.25.0"
+	"packageManager": "pnpm@11.1.3"
 }


### PR DESCRIPTION
## The problem

`8.0.0-beta.10` was versioned and merged (#644) but **failed to publish**:

```
Some packages failed to publish:
type-plus@8.0.0-beta.10
└ E404: 404 Not Found - PUT https://registry.npmjs.org/type-plus - Not found
```

npm returns `E404` on `PUT` when the request arrives unauthenticated — i.e. the OIDC token exchange never happened. Failed twice (original run and a re-run).

## Cause

`changeset publish` does not shell out to `npm publish`. In a pnpm workspace `@changesets/cli` hard-selects its pnpm code path (`getPublishTool()` in `dist/getPublishPlan.mjs`) and runs `pnpm publish`, which does the trusted-publishing token exchange itself via `libnpmpublish`. So the **pnpm** version decides whether OIDC works; the globally installed npm 11.19.1 is irrelevant on this path.

Clean A/B on a single variable — same workflow, same runner, same npm 11.19.1, same `@changesets/cli` 3.0.1, ~2.5 h apart:

| pnpm | run | result |
| --- | --- | --- |
| 11.1.3 | [33532473033](https://github.com/unional/type-plus/actions/runs/33532473033) | `8.0.0-beta.9` published, with provenance |
| 11.25.0 | [33547277466](https://github.com/unional/type-plus/actions/runs/33547277466) | `E404`, twice |

The bump from `pnpm@11.1.3` to `pnpm@11.25.0` came in with #637. Every publish since has been the first one to actually have something to publish, which is why it surfaced now rather than then.

11.1.3 already contains [pnpm/pnpm#11526](https://github.com/pnpm/pnpm/pull/11526), the fix for the known 11.0.x OIDC `E404`. Nothing in the 11.2.0 → 11.25.0 release notes claims an OIDC fix, and no regression is filed upstream — so this looks like an unreported regression in one of the publish-auth / registry-config refactors after 11.1.3 (`pnpm publish` + OIDC is not covered by pnpm's own release CI, which still uses a static `NPM_TOKEN` for most packages).

There is no flag, env var or changesets escape hatch to opt out of the pnpm publish path, so pinning is the only lever this repo has.

## The change

One line: `packageManager` back to `pnpm@11.1.3`. `pnpm-lock.yaml` is `lockfileVersion: 9.0` and installs clean under 11.1.3 with no lockfile change.

## Follow-ups (not in this PR)

- Renovate will try to bump `packageManager` back. Worth an ignore/pin rule until upstream is fixed.
- Worth filing upstream on pnpm/pnpm — this is the single-variable reproduction they asked for in pnpm/pnpm#11566.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014RLRX3QtRpgCfDt16KShQC