### PR TITLE
revert: unpin pnpm — 11.1.3 does not fix the publish E404

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,5 +42,5 @@
 		"typescript": "catalog:",
 		"vitest": "^4.0.15"
 	},
-	"packageManager": "pnpm@11.1.3"
+	"packageManager": "pnpm@11.25.0"
 }


### PR DESCRIPTION
Reverts the pin from #647.

#647 pinned `packageManager` back to `pnpm@11.1.3` on the strength of what looked like a clean A/B: pnpm 11.1.3 published `8.0.0-beta.9` with provenance ([run 33532473033](https://github.com/unional/type-plus/actions/runs/33532473033)), pnpm 11.25.0 hit `E404: 404 Not Found - PUT https://registry.npmjs.org/type-plus` ([run 33547277466](https://github.com/unional/type-plus/actions/runs/33547277466)).

The release run on 11.1.3 ([run 33549558188](https://github.com/unional/type-plus/actions/runs/33549558188)) failed **identically**. pnpm was not the variable, so the downgrade buys nothing — restoring the version #637 brought in.

`8.0.0-beta.10` is still unpublished. See the report on the CJS fix (#641) for what is left to investigate: nothing in this repo's publish path changed between the 16:36 UTC success and the 19:06 UTC failure — same `release.yml`, same `cyberuni/.github@v2` resolved SHA, same `@changesets/cli` 3.0.1, same npm 11.19.1, same `.npmrc`, OIDC subject claim still `use_default: true` — which points at the npm-side trusted publisher configuration for `type-plus` rather than at anything here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014RLRX3QtRpgCfDt16KShQC