### PR TITLE
chore: repoint repository metadata and badges to cyberuni/type-plus

### DIFF
--- a/apps/website/astro.config.mjs
+++ b/apps/website/astro.config.mjs
@@ -17,7 +17,7 @@ export default defineConfig({
 				{
 					icon: 'github',
 					label: 'GitHub',
-					href: 'https://github.com/unional/type-plus',
+					href: 'https://github.com/cyberuni/type-plus',
 				},
 			],
 			sidebar: [

--- a/apps/website/src/content/docs/reference/categories.md
+++ b/apps/website/src/content/docs/reference/categories.md
@@ -3,7 +3,7 @@ title: Categories
 description: What does those icons mean?
 ---
 
-The types and utilities in [`type-plus`](https://github.com/unional/type-plus) can be categorized in one or more categories.
+The types and utilities in [`type-plus`](https://github.com/cyberuni/type-plus) can be categorized in one or more categories.
 
 They can fit into multiple categories because they can be customizable.
 

--- a/info.md
+++ b/info.md
@@ -530,12 +530,12 @@ test results immediately as you type, and see the results in
 your editor right next to your code.
 
 [@gcanti]: https://github.com/gcanti
-[codecov_image]: https://codecov.io/gh/unional/type-plus/branch/main/graph/badge.svg
-[codecov_url]: https://codecov.io/gh/unional/type-plus
+[codecov_image]: https://codecov.io/gh/cyberuni/type-plus/branch/main/graph/badge.svg
+[codecov_url]: https://codecov.io/gh/cyberuni/type-plus
 [downloads_image]: https://img.shields.io/npm/dm/type-plus.svg?style=flat
 [expect-type]: https://github.com/mmkal/expect-type
-[github_action_url]: https://github.com/unional/type-plus/actions
-[github_release]: https://github.com/unional/type-plus/workflows/release/badge.svg
+[github_action_url]: https://github.com/cyberuni/type-plus/actions
+[github_release]: https://github.com/cyberuni/type-plus/workflows/release/badge.svg
 [hotscript]: https://github.com/gvergnaud/hotscript
 [npm_image]: https://img.shields.io/npm/v/type-plus.svg?style=flat
 [npm_url]: https://npmjs.org/package/type-plus

--- a/packages/kind/package.json
+++ b/packages/kind/package.json
@@ -9,13 +9,13 @@
     "type",
     "types"
   ],
-  "homepage": "https://github.com/unional/type-plus/tree/main/packages/kind#readme",
+  "homepage": "https://github.com/cyberuni/type-plus/tree/main/packages/kind#readme",
   "bugs": {
-    "url": "https://github.com/unional/type-plus/issues"
+    "url": "https://github.com/cyberuni/type-plus/issues"
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/unional/type-plus.git",
+    "url": "https://github.com/cyberuni/type-plus.git",
     "directory": "packages/kind"
   },
   "license": "MIT",

--- a/packages/type-plus/package.json
+++ b/packages/type-plus/package.json
@@ -13,13 +13,13 @@
     "typings",
     "utils"
   ],
-  "homepage": "https://github.com/unional/type-plus/tree/main/packages/type-plus#readme",
+  "homepage": "https://github.com/cyberuni/type-plus/tree/main/packages/type-plus#readme",
   "bugs": {
-    "url": "https://github.com/unional/type-plus/issues"
+    "url": "https://github.com/cyberuni/type-plus/issues"
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/unional/type-plus.git",
+    "url": "https://github.com/cyberuni/type-plus.git",
     "directory": "packages/type-plus"
   },
   "license": "MIT",

--- a/packages/type-plus/readme.md
+++ b/packages/type-plus/readme.md
@@ -1348,13 +1348,13 @@ Whenever possible, I add attribution to the person who created those **codes** i
 - [`earl`]: Ergonomic, modern and type-safe assertion library for TypeScript
 
 [@gcanti]: https://github.com/gcanti
-[codecov_image]: https://codecov.io/gh/unional/type-plus/branch/main/graph/badge.svg
-[codecov_url]: https://codecov.io/gh/unional/type-plus
+[codecov_image]: https://codecov.io/gh/cyberuni/type-plus/branch/main/graph/badge.svg
+[codecov_url]: https://codecov.io/gh/cyberuni/type-plus
 [downloads_image]: https://img.shields.io/npm/dm/type-plus.svg?style=flat
 [`earl`]: https://github.com/l2beat/earl
 [`expect-type`]: https://github.com/mmkal/expect-type
-[github_action_url]: https://github.com/unional/type-plus/actions
-[github_release]: https://github.com/unional/type-plus/workflows/release/badge.svg
+[github_action_url]: https://github.com/cyberuni/type-plus/actions
+[github_release]: https://github.com/cyberuni/type-plus/workflows/release/badge.svg
 [`hotscript`]: https://github.com/gvergnaud/hotscript
 [npm_image]: https://img.shields.io/npm/v/type-plus.svg?style=flat
 [npm_url]: https://npmjs.org/package/type-plus
@@ -1364,7 +1364,7 @@ Whenever possible, I add attribution to the person who created those **codes** i
 [`ts-expect`]: https://github.com/TypeStrong/ts-expect
 [`ts-toolbelt`]: https://github.com/millsp/ts-toolbelt
 [`type-fest`]: https://github.com/sindresorhus/type-fest
-[`type-plus`]: https://github.com/unional/type-plus
+[`type-plus`]: https://github.com/cyberuni/type-plus
 [`type-zoo`]: https://github.com/pelotom/type-zoo
 [`typelevel-ts`]: https://github.com/gcanti/typelevel-ts
 [`typepark`]: https://github.com/kgtkr/typepark

--- a/readme.md
+++ b/readme.md
@@ -29,11 +29,11 @@ git push
 # create PR
 ```
 
-[codecov_image]: https://codecov.io/gh/unional/type-plus/branch/main/graph/badge.svg
-[codecov_url]: https://codecov.io/gh/unional/type-plus
+[codecov_image]: https://codecov.io/gh/cyberuni/type-plus/branch/main/graph/badge.svg
+[codecov_url]: https://codecov.io/gh/cyberuni/type-plus
 [downloads_image]: https://img.shields.io/npm/dm/type-plus.svg?style=flat
-[github_action_url]: https://github.com/unional/type-plus/actions
-[github_release]: https://github.com/unional/type-plus/workflows/release/badge.svg
+[github_action_url]: https://github.com/cyberuni/type-plus/actions
+[github_release]: https://github.com/cyberuni/type-plus/workflows/release/badge.svg
 [npm_image]: https://img.shields.io/npm/v/type-plus.svg?style=flat
 [npm_url]: https://npmjs.org/package/type-plus
 [TypeScript]: https://www.typescriptlang.org


### PR DESCRIPTION
Follow-up to the `unional/type-plus` → `cyberuni/type-plus` transfer.

The release now authenticates against npm (the `E404 PUT` is gone — the trusted-publisher registration matches the new owner), but publishing fails at provenance verification:

```
E422: Error verifying sigstore provenance bundle: Failed to validate repository
information: package.json: "repository.url" is "https://github.com/unional/type-plus.git",
expected to match "https://github.com/cyberuni/type-plus" from provenance
```

This updates `homepage` / `repository` / `bugs` in both packages, plus codecov and Actions badge URLs in the readmes and the website config.

**No changeset, deliberately.** `8.0.0-beta.10` is already on `main` and unpublished — it carries the CJS packaging fix (`cjs/package.json` with `{"type":"commonjs"}`). A changeset would make the release open a Version Packages PR instead of publishing, superseding beta.10 with a beta.11 and leaving the CJS fix unpublished. The metadata change ships inside beta.10.

`old/checker` is untouched — `@type-plus/checker` is private and publishes nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014RLRX3QtRpgCfDt16KShQC