### PR TITLE
chore: give the soak a window, and delete the inert .npmrc

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-minimumreleaseage=1440

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -7,19 +7,18 @@ allowBuilds:
   fsevents: true
   sharp: true
 
-# Pinned exclusions from the 24h supply-chain soak in `.npmrc`
-# (`minimumreleaseage=1440`). NOT a weakening of the policy: the soak still
-# governs every other package, and every future release of these two — only
-# these exact versions are let through, because they are the upstream releases
-# this repo is deliberately picking up as part of the modernization sweep.
+# Supply-chain soak: no dependency may be installed until it is 24h old.
+# `minimumReleaseAge` must be set here, not in `.npmrc` - `minimumreleaseage` is not a
+# valid npm key, so from `.npmrc` it never reaches pnpm's typed config and the soak is
+# inert. Strict mode makes a too-young resolution fail the install instead of being
+# silently appended to `minimumReleaseAgeExclude` and installed anyway; with no window
+# set, strict mode on its own enforces nothing.
 #
-# Both were reviewed by hand: `unpartial@1.0.7` and `tersify@4.0.6` are the
-# current `latest` on the registry, published by the same owner as this repo
-# with provenance attestations. Remove these entries once they age past 24h.
+# To take something younger than the window, add an exact version to a
+# `minimumReleaseAgeExclude:` list here with the reason and the date it becomes
+# removable - and drop it again once the soak has elapsed.
+minimumReleaseAge: 1440 # 1 day
 minimumReleaseAgeStrict: true
-minimumReleaseAgeExclude:
-  - tersify@4.0.6
-  - unpartial@1.0.7
 
 catalog:
   typescript: ~5.6.0


### PR DESCRIPTION
`pnpm-workspace.yaml` carried `minimumReleaseAgeStrict: true` with **no `minimumReleaseAge`**, so the supply-chain soak enforced nothing. `pnpm config get minimumReleaseAge` returned `undefined` on `main`.

## Why it looked fine

The window did exist — in `.npmrc`, as `minimumreleaseage=1440`. That is **not a valid npm key**, so it never reaches pnpm's typed config. The `pnpm-workspace.yaml` comment block cited that line as the source of the policy, which is exactly why nobody noticed: the file documented a control it did not have.

`.npmrc` is deleted rather than fixed — that inert line was its only content, and leaving a second, non-functional home for the setting is what caused this.

## Also: the two exclusions are now expired

`tersify@4.0.6` and `unpartial@1.0.7` both published **2026-09-01**; their 24h window elapsed 2026-09-02. The comment even said "Remove these entries once they age past 24h."

## Verified, not assumed

```
pnpm config get minimumReleaseAge        -> 1440    (was: undefined)
pnpm config get minimumReleaseAgeStrict  -> true
pnpm install --frozen-lockfile           -> resolves, no lockfile change
```

No package manifest, source file or lockfile is touched. Nothing here affects the `8.0.0-beta` prerelease queue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ETjy9oQGyETyFmDBdR9Egz