### PR TITLE
chore: pin the local toolchain for mise

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,8 @@
+# The local toolchain, pinned. `mise install` gets you the node and pnpm this
+# repo is developed against.
+#
+# CI does NOT read this file — it selects its own node through setup-node. Keep
+# `pnpm` here in step with `packageManager` in package.json; corepack reads that one.
+[tools]
+node = "22"
+pnpm = "11.25.0"


### PR DESCRIPTION
`mise install` now gets the node and package manager this repo is developed against, instead of whatever the shell happens to have.

The pin **mirrors `packageManager` in package.json** rather than introducing a second opinion — corepack reads that field, and two independent declarations would drift the first time one of them moved. Node comes from `engines.node` where the repo declares one, floored at 22.

CI is unaffected: it selects its own node through setup-node and never reads this file.

Part of a sweep adding the same file across the org.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0163FWV18YYf6AVN3qAd4fYi