### PR TITLE
fix(type-plus): name the lib the type tests need instead of inheriting it

### DIFF
--- a/packages/type-plus/tsconfig.base.json
+++ b/packages/type-plus/tsconfig.base.json
@@ -2,6 +2,12 @@
 	"extends": "@repobuddy/typescript/tsconfig/monorepo",
 	"compilerOptions": {
 		"composite": false,
+		// `target` stays at ES2020 for what we emit. The specs, though, exercise
+		// ES2022 runtime methods (`Array.prototype.at`), which only compiled
+		// because `@types/node` <= 18 declares them globally via
+		// `RelativeIndexable`. It stopped doing that in v20, so name the lib
+		// here rather than lean on a transitive type package to supply it.
+		"lib": ["ES2022"],
 		"rootDir": "src",
 		"skipLibCheck": true
 	},


### PR DESCRIPTION
`packages/type-plus/src/array/array.at.spec.ts` calls `Array.prototype.at` — an ES2022 method — while the package compiles at `target: ES2020`. That only ever worked because `@types/node` up to v18 declares `at` globally through its `RelativeIndexable` interface. From v20 on it doesn't, so #639 (`@types/node` → v24) fails `test:type` on all three compilers in the matrix:

```
src/array/array.at.spec.ts(6,22): error TS2550: Property 'at' does not exist on type '(string | number)[]'.
src/array/array.at.spec.ts(13,22): error TS2339: Property 'at' does not exist on type 'readonly [1, 2, "3"]'.
src/array/array.at.spec.ts(15,2): error TS2578: Unused '@ts-expect-error' directive.
```

Leaning on a transitive `@types` package to supply lib declarations is the actual bug; the `@types/node` bump only exposed it. So set `lib: ["ES2022"]` in `tsconfig.base.json`.

`target` stays at ES2020, so **nothing about the emitted JavaScript changes** — `lib` only tells the checker what the runtime provides. Landing this separately from #639 because Renovate force-pushes that branch and drops commits added to it.

## Verification
`pnpm verify` green on this branch (7/7 turbo tasks), and `test:type` passes on ts-5.4, ts-5.5, and latest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F7THq8F2FNErtYrhJwFaNK