### PR TITLE
fix(ci): build type-plus before the docs site

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -29,7 +29,10 @@ jobs:
           node-version: 24
           cache: pnpm
       - run: pnpm install --frozen-lockfile
-      - run: pnpm --filter website build
+      # Through turbo, not `pnpm --filter`: the twoslash samples import
+      # `type-plus`, so its declarations have to be built first, and
+      # `website#build` already declares that dependency in turbo.json.
+      - run: pnpm exec turbo run build --filter=website
       - uses: actions/configure-pages@v5
       - uses: actions/upload-pages-artifact@v4
         with:


### PR DESCRIPTION
The first real `deploy-docs` run [failed](https://github.com/cyberuni/type-plus/actions/runs/34007691262):

```
Plugin "expressive-code-twoslash" caused an error in its "preprocessCode" hook.
index.ts
  [2307] 29 - Cannot find module 'type-plus' or its corresponding type declarations.
  Location: apps/website/src/content/docs/guides/getting-started.mdx
```

The twoslash samples are compiled by the real TypeScript compiler and `import` from `type-plus`, so the package's declarations must exist before Astro renders the pages. The job ran `pnpm --filter website build`, which bypasses turbo and builds only the site.

This passed locally in #650 only because a previous `pnpm verify` had left `packages/type-plus/esm` on disk. On a clean checkout it cannot work.

`website#build` already declares `dependsOn: ["^build"]` in `turbo.json`, so routing through turbo is all that's needed.

## Verification
`pnpm run clean` (removing the built output), then `pnpm exec turbo run build --filter=website --force` — 2 tasks run, `type-plus#build` then `website#build`, 22 pages built.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F7THq8F2FNErtYrhJwFaNK