### PR TITLE
docs(changeset): correct how the compiler range is checked

### DIFF
--- a/.changeset/olive-pots-repeat.md
+++ b/.changeset/olive-pots-repeat.md
@@ -6,9 +6,10 @@ Support TypeScript 5.4 and up.
 
 The `typescript` peer range widens from `>= 5.6.0` to `>= 5.4.0`. Nothing in
 the published types ever required 5.6 — the range was simply narrower than
-what the compiler matrix tested. The emitted declarations are now compiled
-under 5.4, 5.5, 5.6 and 6.0 on every build, so the range is checked rather
+what the compiler matrix tested. `verify:dts` now type-checks the emitted
+`esm/index.d.ts` with 5.4, 5.5, 5.6 and 6.0, so the range is checked rather
 than asserted.
 
-The package is also now built with TypeScript 7. Emitted JavaScript is
-unchanged; the declarations differ only in how the compiler renders them.
+The package is also now built with TypeScript 7 — one build, as before.
+Emitted JavaScript is unchanged; the declarations differ only in how the
+compiler renders them.


### PR DESCRIPTION
The changeset from #655 said the emitted declarations are "compiled under 5.4, 5.5, 5.6 and 6.0 on every build". That reads as four builds; only one is distributed.

What actually happens:

- One build, emitted by TypeScript 7 (`typescript` is the catalog `~7.0.0`).
- `verify:dts` type-checks that single emitted `esm/index.d.ts` with `ts-5.4`, `ts-5.5`, `ts-5.6` and `ts-6.0`, `skipLibCheck` off.
- `test:type:*` checks `src` under each of the same compilers.

So the older compilers only read the output — they never emit. Wording corrected to say that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F7THq8F2FNErtYrhJwFaNK