### PR TITLE
feat(testType): add defer and assert for reusable type-test helpers

### DIFF
--- a/.changeset/lucky-apes-defer.md
+++ b/.changeset/lucky-apes-defer.md
@@ -1,0 +1,35 @@
+---
+'type-plus': minor
+---
+
+Add `testType.defer` and `testType.assert` for deferred type testing.
+
+A `testType.*` check asserts immediately: the expectation is an argument, so
+the failure is reported where the check is written. That makes a check
+impossible to extract into a reusable helper — the helper body is checked once,
+against type parameters that are not yet resolved, so nothing there can pass or
+fail.
+
+`testType.defer.*` takes no argument and returns the result as a type instead.
+A helper returns the results it collected, and `testType.assert()` checks them
+at the call site, where the type parameters are resolved:
+
+```ts
+function testMyType<T>() {
+	return [testType.defer.string<T>(), testType.defer.not.never<T>()]
+}
+
+it('blah', () => { testType.assert(testMyType<'a'>()) }) // passes
+it('bruh', () => { testType.assert(testMyType<1>()) })   // fails here
+```
+
+`testType.assert()` accepts results in any shape a helper returns — a single
+result, an array, an object, or any nesting of those. `testType.defer.not.*` is
+the deferred form of passing `false`. Deferred checks take the same options as
+their immediate counterparts, in the same position and merged over the same
+defaults. Every check has a deferred form except `inspect`, which is a
+development aid rather than a check.
+
+A failing check resolves to `testType.Failed<Check, Actual, Expected>` rather
+than a bare `false`, so the compiler error names the check that failed and the
+types it compared.

--- a/apps/website/src/content/docs/api/testing.md
+++ b/apps/website/src/content/docs/api/testing.md
@@ -136,6 +136,85 @@ testType.strictCanAssign<number | string, number, { distributive: true }>(true)
 distributive or exact dimension. (`Equal.$Options` is `$Selection.$BaseOptions`: branch overrides
 only.)
 
+### Deferred checks
+
+Each `testType.*` check asserts *immediately* — the expectation is an argument, so the failure lands
+where the check is written. That is what stops a check from being extracted into a reusable helper: the
+helper body is checked once, against type parameters that are not yet resolved, so nothing there can
+either pass or fail.
+
+`testType.defer.*` takes no argument and returns the result as a type instead. A helper returns the
+results it collected, and `testType.assert()` checks them at the call site, where the type parameters
+are resolved.
+
+```ts
+import { testType } from 'type-plus'
+
+function testMyType<T>() {
+	return [
+		testType.defer.string<T>(),
+		testType.defer.not.never<T>(),
+	]
+}
+
+it('blah', () => { testType.assert(testMyType<'a'>()) }) // passes
+it('bruh', () => { testType.assert(testMyType<1>()) })   // fails here, not in the helper
+```
+
+```ts
+testType.defer.<check><...>(): true | testType.Failed<Check, Actual, Expected>
+testType.defer.not.<check><...>(): true | testType.Failed<Check, Actual, Expected>
+testType.assert(...results: testType.Passed[]): void
+```
+
+Every check listed above has a deferred form, with the same type parameters. `inspect` does not — it is
+a development aid, not a check.
+
+`testType.assert()` accepts results in any shape a helper finds convenient to return: a single result,
+an array, an object, or any nesting of those.
+
+```ts
+function testMyType<T>() {
+	return {
+		isString: testType.defer.string<T>(),
+		isNotNumber: testType.defer.not.number<T>(),
+	}
+}
+
+testType.assert(testMyType<'a'>())
+```
+
+`testType.defer.not.*` is the deferred form of passing `false` to the immediate check, so
+`testType.defer.not.equal<A, B>()` mirrors `testType.equal<A, B>(false)`.
+
+Deferred checks take the same [options](#options) as their immediate counterparts, in the same
+position and merged over the same defaults:
+
+```ts
+testType.defer.string<'a', { exact: true }>()          // fails — the literal is not exactly `string`
+testType.defer.array<[string], { exact: false }>()     // passes — `array`'s `exact: true` turned off
+testType.defer.canAssign<number | string, number, { distributive: false }>()
+```
+
+so a helper can fix an option once and every call site inherits it:
+
+```ts
+function testExactly<T>() {
+	return testType.defer.string<T, { exact: true }>()
+}
+
+testType.assert(testExactly<string>()) // passes
+testType.assert(testExactly<'a'>())    // fails here
+```
+
+A failing check resolves to `testType.Failed<Check, Actual, Expected>` rather than a bare `false`, so the
+compiler error names the check and the types it compared:
+
+```
+Argument of type '{ isString: testType.Failed<"string", 1, string>; isNotNumber: true; }'
+is not assignable to parameter of type 'Passed'.
+```
+
 ### testType.inspect
 
 ```ts

--- a/packages/type-plus/readme.md
+++ b/packages/type-plus/readme.md
@@ -863,6 +863,18 @@ testType.equal<A, B>(true) // A is equal to B
 testType.never<T>(false) // T is not `never`
 ```
 
+To reuse a check across tests, extract it with the deferred form and assert it at the call site:
+
+```ts
+import { testType } from 'type-plus'
+
+function testMyType<T>() {
+	return [testType.defer.string<T>(), testType.defer.not.never<T>()]
+}
+
+testType.assert(testMyType<'a'>())
+```
+
 You can learn more about them in the [docs](./src/testing/readme.md).
 
 ## Constant Types

--- a/packages/type-plus/src/testing/readme.md
+++ b/packages/type-plus/src/testing/readme.md
@@ -34,6 +34,45 @@ testType.array<[string], { exact: false }>(true) // `array` defaults to `exact: 
 testType.string<'a' | 1, { distributive: true }>(true) // distributes to `boolean`
 ```
 
+## `testType.defer` and `testType.assert`
+
+`testType.*` checks assert *immediately* — the expectation is an argument, so the failure is reported
+where the check is written. That makes them impossible to extract into a reusable helper: the helper
+body is checked once, against unresolved type parameters.
+
+`testType.defer.*` takes no argument and returns the result as a type instead. Return the results from
+the helper and hand them to `testType.assert()` at the call site, where the type parameters are
+resolved and the failure belongs.
+
+```ts
+import { testType } from 'type-plus'
+
+function testMyType<T>() {
+  return [
+    testType.defer.string<T>(),
+    testType.defer.not.never<T>(),
+  ]
+}
+
+it('blah', () => { testType.assert(testMyType<'a'>()) }) // passes
+it('bruh', () => { testType.assert(testMyType<1>()) })   // fails here, not in the helper
+```
+
+`testType.assert()` takes any number of results in any shape — a single result, an array, an object,
+or any nesting of those — so a helper can return whatever reads best.
+
+`testType.defer.not.*` is the deferred form of passing `false`:
+`testType.defer.not.equal<A, B>()` mirrors `testType.equal<A, B>(false)`.
+
+Deferred checks take the same options as their immediate counterparts:
+`testType.defer.string<T, { exact: true }>()`.
+
+A failing check resolves to `testType.Failed<Check, Actual, Expected>`, so the compiler error names the
+check that failed along with the types involved.
+
+Every `testType` check has a deferred form except `inspect`, which is a development aid rather than a
+check.
+
 ## [testType.inspect](./test_type.ts)
 
 `testType.inspect<T>(fn)`

--- a/packages/type-plus/src/testing/test_type.defer.spec.ts
+++ b/packages/type-plus/src/testing/test_type.defer.spec.ts
@@ -215,3 +215,23 @@ it('carries options through a deferred helper', () => {
 	// @ts-expect-error
 	testType.assert(testExactly<'a'>())
 })
+
+it('does not let a degenerate type through the assert', () => {
+	// `any` in the type under test must not make the failure assignable to `Passed`.
+	// @ts-expect-error
+	testType.assert(testType.defer.equal<any, string>())
+
+	// nor `never`.
+	// @ts-expect-error
+	testType.assert(testType.defer.equal<never, string>())
+
+	// nor a failure hidden behind an optional property.
+	// @ts-expect-error
+	testType.assert({} as { a?: ReturnType<typeof testType.defer.string<1>> })
+})
+
+it('passes vacuously when there is nothing to assert', () => {
+	testType.assert()
+	testType.assert([])
+	testType.assert({})
+})

--- a/packages/type-plus/src/testing/test_type.defer.spec.ts
+++ b/packages/type-plus/src/testing/test_type.defer.spec.ts
@@ -1,0 +1,217 @@
+import { it } from 'vitest'
+
+import { testType } from '../index.js'
+
+it('defers a check so it can live in a reusable helper', () => {
+	// the helper body type checks on its own — `T` is not resolved here,
+	// so nothing can fail yet.
+	function testMyType<T>() {
+		return testType.defer.string<T>()
+	}
+
+	testType.assert(testMyType<'a'>())
+
+	// the failure is reported here, at the helper's call site.
+	// @ts-expect-error
+	testType.assert(testMyType<1>())
+})
+
+it('accepts a single result', () => {
+	testType.assert(testType.defer.equal<1, 1>())
+
+	// @ts-expect-error
+	testType.assert(testType.defer.equal<1, 2>())
+})
+
+it('accepts multiple results as arguments', () => {
+	testType.assert(testType.defer.equal<1, 1>(), testType.defer.number<1>())
+
+	// @ts-expect-error
+	testType.assert(testType.defer.equal<1, 1>(), testType.defer.string<1>())
+})
+
+it('accepts an array of results', () => {
+	function testMyType<T>() {
+		return [testType.defer.string<T>(), testType.defer.not.never<T>()]
+	}
+
+	testType.assert(testMyType<'a'>())
+
+	// @ts-expect-error
+	testType.assert(testMyType<never>())
+})
+
+it('accepts an object of results', () => {
+	function testMyType<T>() {
+		return {
+			isString: testType.defer.string<T>(),
+			isNotNumber: testType.defer.not.number<T>(),
+		}
+	}
+
+	testType.assert(testMyType<'a'>())
+
+	// @ts-expect-error
+	testType.assert(testMyType<1>())
+})
+
+it('accepts results nested to any depth', () => {
+	function inner<T>() {
+		return { isString: testType.defer.string<T>() }
+	}
+	function outer<T>() {
+		return [inner<T>(), [testType.defer.not.never<T>()]]
+	}
+
+	testType.assert(outer<'a'>())
+
+	// @ts-expect-error
+	testType.assert(outer<1>())
+})
+
+it('composes helpers that take value arguments', () => {
+	function testReturnType<R>(_fn: () => R) {
+		return testType.defer.number<R>()
+	}
+
+	testType.assert(testReturnType(() => 1))
+
+	// @ts-expect-error
+	testType.assert(testReturnType(() => 'a'))
+})
+
+it('covers equal with three types', () => {
+	testType.assert(testType.defer.equal<1, 1, 1>())
+
+	// @ts-expect-error
+	testType.assert(testType.defer.equal<1, 1, 2>())
+})
+
+it('mirrors the distributivity of the immediate checks', () => {
+	// `canAssign` is distributive, so a union can widen to `boolean`,
+	// which the immediate check accepts for both `true` and `false`.
+	testType.canAssign<number | string, number>(true)
+	testType.canAssign<number | string, number>(false)
+	testType.assert(testType.defer.canAssign<number | string, number>())
+	testType.assert(testType.defer.not.canAssign<number | string, number>())
+
+	// `strictCanAssign` is not distributive.
+	testType.assert(testType.defer.strictCanAssign<number | string, number | string>())
+	testType.assert(testType.defer.not.strictCanAssign<number | string, number>())
+
+	// @ts-expect-error
+	testType.assert(testType.defer.strictCanAssign<number | string, number>())
+})
+
+it('negates a check with `not`', () => {
+	testType.assert(testType.defer.not.equal<1, 2>())
+
+	// @ts-expect-error
+	testType.assert(testType.defer.not.equal<1, 1>())
+})
+
+it('covers every check `testType` has, except `inspect`', () => {
+	testType.assert(
+		testType.defer.any<any>(),
+		testType.defer.array<number[]>(),
+		testType.defer.bigint<1n>(),
+		testType.defer.boolean<true>(),
+		testType.defer.canAssign<1, number>(),
+		testType.defer.equal<1, 1>(),
+		testType.defer.false<false>(),
+		testType.defer.function<() => void>(),
+		testType.defer.never<never>(),
+		testType.defer.null<null>(),
+		testType.defer.number<1>(),
+		testType.defer.object<{ a: 1 }>(),
+		testType.defer.strictBigint<bigint>(),
+		testType.defer.strictBoolean<boolean>(),
+		testType.defer.strictCanAssign<1, number>(),
+		testType.defer.strictFunction<Function>(),
+		testType.defer.strictNumber<number>(),
+		testType.defer.strictString<string>(),
+		testType.defer.string<'a'>(),
+		testType.defer.symbol<symbol>(),
+		testType.defer.true<true>(),
+		testType.defer.tuple<[1, 2]>(),
+		testType.defer.undefined<undefined>(),
+		testType.defer.unknown<unknown>(),
+		testType.defer.void<void>(),
+	)
+
+	testType.assert(
+		testType.defer.not.any<1>(),
+		testType.defer.not.array<1>(),
+		testType.defer.not.bigint<1>(),
+		testType.defer.not.boolean<1>(),
+		testType.defer.not.canAssign<string, number>(),
+		testType.defer.not.equal<1, 2>(),
+		testType.defer.not.false<true>(),
+		testType.defer.not.function<1>(),
+		testType.defer.not.never<1>(),
+		testType.defer.not.null<1>(),
+		testType.defer.not.number<'a'>(),
+		testType.defer.not.object<1>(),
+		testType.defer.not.strictBigint<1n>(),
+		testType.defer.not.strictBoolean<true>(),
+		testType.defer.not.strictCanAssign<number | string, number>(),
+		testType.defer.not.strictFunction<() => void>(),
+		testType.defer.not.strictNumber<1>(),
+		testType.defer.not.strictString<'a'>(),
+		testType.defer.not.string<1>(),
+		testType.defer.not.symbol<1>(),
+		testType.defer.not.true<false>(),
+		testType.defer.not.tuple<1>(),
+		testType.defer.not.undefined<1>(),
+		testType.defer.not.unknown<1>(),
+		testType.defer.not.void<1>(),
+	)
+})
+
+it('takes the same options as the immediate checks', () => {
+	// the option lands after the type under test, so the no-options form is unchanged.
+	testType.assert(testType.defer.string<'a'>())
+
+	// `exact` narrows the check the same way it does immediately.
+	testType.string<'a', { exact: true }>(false)
+	testType.assert(testType.defer.not.string<'a', { exact: true }>())
+	testType.assert(testType.defer.string<string, { exact: true }>())
+
+	// @ts-expect-error `exact: true` makes the literal fail
+	testType.assert(testType.defer.string<'a', { exact: true }>())
+})
+
+it('merges options over each check’s own defaults', () => {
+	// `array` bakes in `exact: true`, so a tuple fails by default.
+	testType.assert(testType.defer.not.array<[string]>())
+	// and turning it off accepts the tuple.
+	testType.assert(testType.defer.array<[string], { exact: false }>())
+
+	// the `strict*` variants bake in `exact: true`, overridable the same way.
+	testType.assert(testType.defer.not.strictString<'a'>())
+	testType.assert(testType.defer.strictString<'a', { exact: false }>())
+})
+
+it('supports the `distributive` option', () => {
+	// the checks default to `distributive: false`, so a union is judged as a whole.
+	testType.assert(testType.defer.not.string<'a' | 1>())
+	// distributing widens the result to `boolean`, which accepts either expectation.
+	testType.assert(testType.defer.string<'a' | 1, { distributive: true }>())
+	testType.assert(testType.defer.not.string<'a' | 1, { distributive: true }>())
+
+	// `canAssign` and `strictCanAssign` take it as their third parameter.
+	testType.assert(testType.defer.not.canAssign<number | string, number, { distributive: false }>())
+	testType.assert(testType.defer.strictCanAssign<number | string, number, { distributive: true }>())
+})
+
+it('carries options through a deferred helper', () => {
+	function testExactly<T>() {
+		return testType.defer.string<T, { exact: true }>()
+	}
+
+	testType.assert(testExactly<string>())
+
+	// the literal fails the exact check, reported at the call site.
+	// @ts-expect-error
+	testType.assert(testExactly<'a'>())
+})

--- a/packages/type-plus/src/testing/test_type.ts
+++ b/packages/type-plus/src/testing/test_type.ts
@@ -241,6 +241,53 @@ export namespace testType {
 		 */
 		void<T, $O extends $Options = {}>(expected: IsVoid<T, $MergeOptions<{ distributive: false }, $O>>): T
 		/**
+		 * Deferred variants of the `testType` checks.
+		 *
+		 * A `testType.*` check asserts *immediately*: the expected value is an argument,
+		 * so the failure is reported where the check is written.
+		 * That makes it impossible to extract a check into a reusable helper —
+		 * the helper body is checked once, against its unresolved type parameters.
+		 *
+		 * A `testType.defer.*` check takes no argument and *returns* the result as a type.
+		 * Collect the results, return them from the helper,
+		 * and hand them to `testType.assert()` at the call site,
+		 * where the type parameters are resolved and the failure belongs.
+		 *
+		 * 🧪 *testing*
+		 *
+		 * @example
+		 * ```ts
+		 * function testMyType<T>() {
+		 *   return [
+		 *     testType.defer.equal<T, string>(),
+		 *     testType.defer.not.never<T>(),
+		 *   ]
+		 * }
+		 *
+		 * it('blah', () => { testType.assert(testMyType<string>()) })
+		 * it('bruh', () => { testType.assert(testMyType<'a'>()) })
+		 * ```
+		 */
+		defer: Defer
+		/**
+		 * Assert that every deferred result passes.
+		 *
+		 * Accepts results in any shape a helper finds convenient to return —
+		 * a single result, an array, an object, or any nesting of those.
+		 *
+		 * A failing result is a {@link testType.Failed} type,
+		 * so the error names the check that failed along with the actual and expected types.
+		 *
+		 * 🧪 *testing*
+		 *
+		 * @example
+		 * ```ts
+		 * testType.assert(testType.defer.equal<1, 1>())
+		 * testType.assert(testMyType<string>(), testMyOtherType<string>())
+		 * ```
+		 */
+		assert(...results: Passed[]): void
+		/**
 		 * A quick way to inspect a type.
 		 *
 		 * The handler receives a `InspectedType` object.
@@ -264,6 +311,254 @@ export namespace testType {
 		 * After trying out the type, remove the line.
 		 */
 		inspect<T>(handler: (t: InspectedType<T>) => unknown): T
+	}
+
+	/**
+	 * A deferred check that passed.
+	 *
+	 * Also the shape `testType.assert()` accepts:
+	 * a passing result, or any array/object nesting of passing results.
+	 */
+	export type Passed = true | readonly Passed[] | { readonly [key: string]: Passed }
+
+	/**
+	 * A deferred check that failed.
+	 *
+	 * It is not assignable to {@link testType.Passed},
+	 * so `testType.assert()` rejects it,
+	 * and the compiler error names the check along with the actual and expected types.
+	 */
+	export interface Failed<Check extends string, Actual, Expected> {
+		failed: Check
+		actual: Actual
+		expected: Expected
+	}
+
+	/**
+	 * Resolves a deferred check to `true` when `Actual` accepts the expectation `Expect`,
+	 * and to `F` (a {@link testType.Failed}) when it does not.
+	 *
+	 * `Expect extends Actual` mirrors how the immediate `testType.*` checks work:
+	 * they accept the expected value when it is assignable to the predicate result,
+	 * so a distributive predicate that widens to `boolean` accepts both `true` and `false`.
+	 */
+	export type Check<Expect extends boolean, Actual, F> = Expect extends Actual ? true : F
+
+	/**
+	 * The name a failed check reports, negated for `testType.defer.not.*`.
+	 */
+	export type CheckName<Expect extends boolean, Name extends string> = Expect extends true ? Name : `not ${Name}`
+
+	/**
+	 * `testType.defer` — the deferred checks, plus `not` for the negated ones.
+	 */
+	export interface Defer extends DeferredTestType<true> {
+		/**
+		 * The negated deferred checks.
+		 *
+		 * `testType.defer.not.equal<A, B>()` is the deferred form of `testType.equal<A, B>(false)`.
+		 */
+		not: DeferredTestType<false>
+	}
+
+	/**
+	 * The deferred mirror of {@link testType.TestType}.
+	 *
+	 * Every check takes the same type parameters as its immediate counterpart,
+	 * takes no value argument,
+	 * and returns `true` when it passes or a {@link testType.Failed} when it does not.
+	 *
+	 * `testType.inspect` has no deferred form — it is a development aid, not a check.
+	 */
+	export interface DeferredTestType<Expect extends boolean> {
+		/**
+		 * Deferred {@link testType.TestType.equal}: is type `A` equal to type `B` and `C`?
+		 */
+		equal<A, B, C>(): Check<Expect, IsEqual<A, B> & IsEqual<A, C>, Failed<CheckName<Expect, 'equal'>, A, B | C>>
+		/**
+		 * Deferred {@link testType.TestType.equal}: is type `A` equal to type `B`?
+		 */
+		equal<A, B>(): Check<Expect, IsEqual<A, B>, Failed<CheckName<Expect, 'equal'>, A, B>>
+		/**
+		 * Deferred {@link testType.TestType.canAssign}: can `A` assign to `B`?
+		 */
+		canAssign<A, B, $O extends $Distributive.Options = {}>(): Check<
+			Expect,
+			Assignable<A, B, $O>,
+			Failed<CheckName<Expect, 'canAssign'>, A, B>
+		>
+		/**
+		 * Deferred {@link testType.TestType.strictCanAssign}: can `A` fully assign to `B`?
+		 */
+		strictCanAssign<A, B, $O extends $Distributive.Options = {}>(): Check<
+			Expect,
+			Assignable<A, B, $MergeOptions<{ distributive: false }, $O>>,
+			Failed<CheckName<Expect, 'strictCanAssign'>, A, B>
+		>
+		/**
+		 * Deferred {@link testType.TestType.any}: is type `T` exactly `any`?
+		 */
+		any<T>(): Check<Expect, IsAny<T>, Failed<CheckName<Expect, 'any'>, T, any>>
+		/**
+		 * Deferred {@link testType.TestType.never}: is type `T` exactly `never`?
+		 */
+		never<T>(): Check<Expect, IsNever<T>, Failed<CheckName<Expect, 'never'>, T, never>>
+		/**
+		 * Deferred {@link testType.TestType.unknown}: is type `T` exactly `unknown`?
+		 */
+		unknown<T>(): Check<Expect, IsUnknown<T>, Failed<CheckName<Expect, 'unknown'>, T, unknown>>
+		/**
+		 * Deferred {@link testType.TestType.array}.
+		 */
+		array<T, $O extends $Options = {}>(): Check<
+			Expect,
+			IsArray<T, $MergeOptions<{ exact: true }, $O>>,
+			Failed<CheckName<Expect, 'array'>, T, unknown[]>
+		>
+		/**
+		 * Deferred {@link testType.TestType.strictBigint}.
+		 */
+		strictBigint<T, $O extends $Options = {}>(): Check<
+			Expect,
+			IsBigint<T, $MergeOptions<{ distributive: false; exact: true }, $O>>,
+			Failed<CheckName<Expect, 'strictBigint'>, T, bigint>
+		>
+		/**
+		 * Deferred {@link testType.TestType.bigint}.
+		 */
+		bigint<T, $O extends $Options = {}>(): Check<
+			Expect,
+			IsBigint<T, $MergeOptions<{ distributive: false }, $O>>,
+			Failed<CheckName<Expect, 'bigint'>, T, bigint>
+		>
+		/**
+		 * Deferred {@link testType.TestType.strictBoolean}.
+		 */
+		strictBoolean<T, $O extends $Options = {}>(): Check<
+			Expect,
+			IsBoolean<T, $MergeOptions<{ distributive: false; exact: true }, $O>>,
+			Failed<CheckName<Expect, 'strictBoolean'>, T, boolean>
+		>
+		/**
+		 * Deferred {@link testType.TestType.boolean}.
+		 */
+		boolean<T, $O extends $Options = {}>(): Check<
+			Expect,
+			IsBoolean<T, $MergeOptions<{ distributive: false }, $O>>,
+			Failed<CheckName<Expect, 'boolean'>, T, boolean>
+		>
+		/**
+		 * Deferred {@link testType.TestType.true}.
+		 */
+		true<T, $O extends $Options = {}>(): Check<
+			Expect,
+			IsTrue<T, $MergeOptions<{ distributive: false }, $O>>,
+			Failed<CheckName<Expect, 'true'>, T, true>
+		>
+		/**
+		 * Deferred {@link testType.TestType.false}.
+		 */
+		false<T, $O extends $Options = {}>(): Check<
+			Expect,
+			IsFalse<T, $MergeOptions<{ distributive: false }, $O>>,
+			Failed<CheckName<Expect, 'false'>, T, false>
+		>
+		/**
+		 * Deferred {@link testType.TestType.strictFunction}.
+		 */
+		strictFunction<T, $O extends $Options = {}>(): Check<
+			Expect,
+			IsStrictFunction<T, $MergeOptions<{ distributive: false }, $O>>,
+			Failed<CheckName<Expect, 'strictFunction'>, T, Function>
+		>
+		/**
+		 * Deferred {@link testType.TestType.function}.
+		 */
+		function<T, $O extends $Options = {}>(): Check<
+			Expect,
+			IsFunction<T, $MergeOptions<{ distributive: false }, $O>>,
+			Failed<CheckName<Expect, 'function'>, T, Function>
+		>
+		/**
+		 * Deferred {@link testType.TestType.null}.
+		 */
+		null<T, $O extends $Options = {}>(): Check<
+			Expect,
+			IsNull<T, $MergeOptions<{ distributive: false }, $O>>,
+			Failed<CheckName<Expect, 'null'>, T, null>
+		>
+		/**
+		 * Deferred {@link testType.TestType.strictNumber}.
+		 */
+		strictNumber<T, $O extends $Options = {}>(): Check<
+			Expect,
+			IsNumber<T, $MergeOptions<{ distributive: false; exact: true }, $O>>,
+			Failed<CheckName<Expect, 'strictNumber'>, T, number>
+		>
+		/**
+		 * Deferred {@link testType.TestType.number}.
+		 */
+		number<T, $O extends $Options = {}>(): Check<
+			Expect,
+			IsNumber<T, $MergeOptions<{ distributive: false }, $O>>,
+			Failed<CheckName<Expect, 'number'>, T, number>
+		>
+		/**
+		 * Deferred {@link testType.TestType.object}.
+		 */
+		object<T, $O extends $Options = {}>(): Check<
+			Expect,
+			IsObject<T, $MergeOptions<{ distributive: false }, $O>>,
+			Failed<CheckName<Expect, 'object'>, T, object>
+		>
+		/**
+		 * Deferred {@link testType.TestType.strictString}.
+		 */
+		strictString<T, $O extends $Options = {}>(): Check<
+			Expect,
+			IsString<T, $MergeOptions<{ distributive: false; exact: true }, $O>>,
+			Failed<CheckName<Expect, 'strictString'>, T, string>
+		>
+		/**
+		 * Deferred {@link testType.TestType.string}.
+		 */
+		string<T, $O extends $Options = {}>(): Check<
+			Expect,
+			IsString<T, $MergeOptions<{ distributive: false }, $O>>,
+			Failed<CheckName<Expect, 'string'>, T, string>
+		>
+		/**
+		 * Deferred {@link testType.TestType.symbol}.
+		 */
+		symbol<T, $O extends $Options = {}>(): Check<
+			Expect,
+			IsSymbol<T, $MergeOptions<{ distributive: false }, $O>>,
+			Failed<CheckName<Expect, 'symbol'>, T, symbol>
+		>
+		/**
+		 * Deferred {@link testType.TestType.tuple}.
+		 */
+		tuple<T, $O extends $Options = {}>(): Check<
+			Expect,
+			IsTuple<T, $MergeOptions<{ distributive: false }, $O>>,
+			Failed<CheckName<Expect, 'tuple'>, T, readonly unknown[]>
+		>
+		/**
+		 * Deferred {@link testType.TestType.undefined}.
+		 */
+		undefined<T, $O extends $Options = {}>(): Check<
+			Expect,
+			IsUndefined<T, $MergeOptions<{ distributive: false }, $O>>,
+			Failed<CheckName<Expect, 'undefined'>, T, undefined>
+		>
+		/**
+		 * Deferred {@link testType.TestType.void}.
+		 */
+		void<T, $O extends $Options = {}>(): Check<
+			Expect,
+			IsVoid<T, $MergeOptions<{ distributive: false }, $O>>,
+			Failed<CheckName<Expect, 'void'>, T, void>
+		>
 	}
 
 	export type InspectedType<T> = {
@@ -342,7 +637,24 @@ export namespace testType {
  * so that the type can be further inspected.
  */
 export const testType = new Proxy({} as testType.TestType, {
-	get(_target, _prop, _receiver) {
-		return (expected: unknown) => expected
+	get(_target, prop, _receiver) {
+		return prop === 'defer' ? defer : (expected: unknown) => expected
 	},
 })
+
+/**
+ * The deferred checks carry their result in the return *type*.
+ * At runtime they have nothing to say, so every one of them is a no-op.
+ */
+function createDefer(withNot: boolean): unknown {
+	return new Proxy(
+		{},
+		{
+			get(_target, prop, _receiver) {
+				return withNot && prop === 'not' ? createDefer(false) : () => undefined
+			},
+		},
+	)
+}
+
+const defer = createDefer(true)


### PR DESCRIPTION
`testType.*` checks assert **immediately** — the expectation is a value argument, so the failure is
reported where the check is written. That is exactly what stops a check from being extracted into a
reusable helper: the helper body is type-checked once, against type parameters that are not yet
resolved, so nothing in it can pass or fail.

The issue asked whether this is solvable at the library level. It is, with one shape change: the
expectation has to move from the helper to the call site.

## What this adds

`testType.defer.*` mirrors every `testType.*` check, takes no argument, and returns the result as a
**type**. A helper returns the results it collected, and `testType.assert()` checks them at the call
site, where the type parameters are resolved:

```ts
function testMyType<T>() {
	return [testType.defer.string<T>(), testType.defer.not.never<T>()]
}

it('blah', () => { testType.assert(testMyType<'a'>()) }) // passes
it('bruh', () => { testType.assert(testMyType<1>()) })   // fails here, not in the helper
```

- `testType.assert()` accepts results in whatever shape a helper finds convenient to return — a single
  result, an array, an object, or any nesting of those.
- `testType.defer.not.*` is the deferred form of passing `false`, so `testType.defer.not.equal<A, B>()`
  mirrors `testType.equal<A, B>(false)`.
- Deferred checks take the same options #370 added to the immediate ones, in the same position and
  merged over the same defaults — `testType.defer.string<T, { exact: true }>()`,
  `testType.defer.array<[string], { exact: false }>()`,
  `testType.defer.canAssign<A, B, { distributive: false }>()`. A helper can fix an option once and
  every call site inherits it.
- Deferred checks keep the distributivity of their immediate counterparts: `defer.canAssign` accepts a
  union that widens to `boolean` for both polarities, `defer.strictCanAssign` does not.
- Every check has a deferred form except `inspect`, which is a development aid rather than a check.

A failing check resolves to `testType.Failed<Check, Actual, Expected>` rather than a bare `false`, so
the compiler error names the check and the types it compared:

```
Argument of type '{ isString: testType.Failed<"string", 1, string>; isNotNumber: true; }'
is not assignable to parameter of type 'Passed'.
```

## The honest limitation

The immediate form still cannot be wrapped. There is no way to make

```ts
function testMyType<T>() { testType.equal<T, string>(true) }
```

report at `testMyType<number>()` — TypeScript checks a function body once, generically. Deferring the
expectation to the call site is the only route across the type-value boundary, so `testType.assert()`
at the call site is a required part of the pattern rather than an implementation detail.

## Runtime

`testType.defer` is a nested `Proxy`; the deferred checks are no-ops, since everything they have to say
is in the return type. No new dependencies, no emitted-JS change beyond the proxy itself.

## Verification

- `pnpm -w turbo build lint test` and `pnpm check` (biome, formatting included) — green.
- `pnpm test:type` — green on TypeScript 5.4, 5.5, 5.6, 6.0 and 7 (the full declared peer range).
- `pnpm verify:dts` — the emitted `esm/index.d.ts` type-checks on 5.4 through 6.0.
- New `test_type.defer.spec.ts` covers the wrapped-helper case in both directions with
  `@ts-expect-error` on the failing call site, plus every deferred check and its `not` form.

Docs updated in `src/testing/readme.md`, the package readme, and the website's Testing page.
Changeset: `minor`.

Closes #360

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HTz9JQodjKCtmsEovrEAX8

