### PR TITLE
docs(type-plus): generate llms.txt from the exported type surface

### DIFF
--- a/.changeset/silver-maps-orient.md
+++ b/.changeset/silver-maps-orient.md
@@ -1,0 +1,16 @@
+---
+'type-plus': patch
+---
+
+Ship a generated `llms.txt`.
+
+`llms.txt` is the orientation layer for an agent meeting the library cold: what
+`type-plus` is, the `Is*` / `$Options` / `$Branch` conventions that govern nearly
+every type in it, and which families exist. Per-symbol detail stays in the
+`.d.ts`, which the agent already has.
+
+The file is generated from the exported surface of `src/index.ts` by
+`scripts/generate-llms-txt.mjs`, never hand-written, and `pnpm docs:llms:check`
+fails the build when it drifts. It is listed in `files`, so it reaches
+`node_modules/type-plus/llms.txt`, and it is also published to
+`https://cyberuni.github.io/type-plus/llms.txt`.

--- a/apps/website/public/llms.txt
+++ b/apps/website/public/llms.txt
@@ -1,0 +1,53 @@
+# type-plus
+
+> 273 utility types and functions for TypeScript, most of which resolve at the type level and emit no runtime code. This file is generated from the exported surface of `src/index.ts`; edit `packages/type-plus/scripts/generate-llms-txt.mjs`, not this file.
+
+Most of `type-plus` is types, not values. Importing a type costs nothing at runtime -- it is erased at compile time, and the shipped declarations are several times the size of the shipped JavaScript. Import types with `import type` and the rest with a plain `import`.
+
+## Conventions
+
+Four conventions govern almost every type in the library. Knowing them is worth more than knowing any individual symbol.
+
+- `Is*<T>` resolves to `true` or `false`. It resolves to `boolean` when `T` cannot be decided one way or the other -- `IsPositive<number>` is `boolean`, because `number` holds both positive and negative values. Every `Is*` type has a matching `IsNot*`.
+- `Is*<T, $O>` takes a second type parameter, an options object. `{ selection: 'filter' }` switches the result from a boolean to `T` itself (or `never` when the check fails), which makes the type usable as a filter over a union.
+- `{ distributive: false }` turns off distribution over unions. By default a check applied to `A | B` is applied to each member and the results are unioned; with distribution off the union is judged as a whole.
+- Every branch of a check is overridable through the same options object: `IsNever<any, { $any: 'any' }>`, and likewise `$unknown`, `$then` and `$else`. Passing the `Is*.$Branch` selector instead -- `IsNever<T, IsNever.$Branch>` -- yields the `$Then` / `$Else` markers, which is what makes a check composable inside another type.
+
+The authoritative, per-symbol detail is the TSDoc in the shipped `.d.ts` files, under `node_modules/type-plus/esm/`. 240 of the 273 exports carry TSDoc; the rest have a name and a signature only. A documented type states what it resolves to in `@example` blocks. Read the declaration before guessing at a signature. In `$type`, `math`, `object`, `predicates`, `string`, `tuple`, `union`, every documented example is pinned by a compiled test, so an example that drifts from the implementation fails to build.
+
+## Guides
+
+- [Getting Started](https://cyberuni.github.io/type-plus/guides/getting-started/): Install, import, and the first utility type.
+- [TypeScript Version Compatibility](https://cyberuni.github.io/type-plus/guides/typescript-version-compatibility/): Which TypeScript versions are supported and why the range matters for a type library.
+
+## Reference
+
+- [Type branching](https://cyberuni.github.io/type-plus/api/type-branching/): The `$Branch`, `$Then` and `$Else` mechanism in full.
+- [Options](https://cyberuni.github.io/type-plus/reference/options/): The `$Options` shapes shared across the library.
+- [Categories](https://cyberuni.github.io/type-plus/reference/categories/): What the category icons in the TSDoc mean.
+- [Status](https://cyberuni.github.io/type-plus/reference/status/): Stability and `@since` markers.
+
+## API
+
+- [Array](https://cyberuni.github.io/type-plus/api/array/): 21 exports from `src/array/` -- ArrayPlus, At, Concat, Filter, FindFirst, FindLast, Head, IntersectOfProps, IsArray, IsNotArray, KeepMatch, Last, MapToProp, PadStart, PropUnion, Reverse, Some, UnionOfProps, UnionOfValues, literalArray, reduceWhile.
+- [Boolean and Logical](https://cyberuni.github.io/type-plus/api/boolean/): 10 exports from `src/boolean/`, `src/logical/` -- And, IsBoolean, IsFalse, IsNotBoolean, IsNotFalse, IsNotTrue, IsTrue, Not, Or, Xor.
+- [Equality](https://cyberuni.github.io/type-plus/api/equality/): 6 exports from `src/equal/` -- $SelectInvert, $SelectInvertStrict, Equal, IsEqual, IsNotEqual, NotEqual.
+- [Function and Functional](https://cyberuni.github.io/type-plus/api/function/): 14 exports from `src/function/`, `src/functional/` -- AnyFunction, ChainFn, ContextBaseShape, ContextBuilder, ContextExtender, EndoFn, ExtractFunction, IsFunction, IsNotFunction, IsNotStrictFunction, IsStrictFunction, compose, context, extractFunction.
+- [Math and Bigint](https://cyberuni.github.io/type-plus/api/math/): 14 exports from `src/bigint/`, `src/math/` -- Abs, Add, Decrement, GreaterThan, Increment, IsBigint, IsBigintLiteral, IsNotBigint, IsNotBigintLiteral, MathPlus, Max, Multiply, StringToBigint, Subtract.
+- [Nominal Types](https://cyberuni.github.io/type-plus/api/nominal/): 8 exports from `src/nominal/` -- Brand, Branded, Flavor, Flavored, FlavoredUnit, brand, flavor, nominalMatch.
+- [Number and Numeric](https://cyberuni.github.io/type-plus/api/number/): 19 exports from `src/number/`, `src/numeric/` -- IsInteger, IsNegative, IsNotInteger, IsNotNegative, IsNotNumber, IsNotNumberLiteral, IsNotNumeric, IsNotPositive, IsNumber, IsNumberLiteral, IsNumeric, IsPositive, NumberPlus, Numeric, NumericPlus, NumericToString, StringToNumber, StringToNumeric, Zero.
+- [Object](https://cyberuni.github.io/type-plus/api/object/): 58 exports from `src/object/` -- ANotB, AdjustExactOptionalProps, AnyRecord, BNotA, Except, ExcludePropType, HasKey, IsDisjoint, IsNotObject, IsObject, IsOptionalKey, IsRecord, KeyTypes, KeysOfOptional, KeysWithDiffType, KnownKeys, LeftJoin, ObjectPlus, Omit, OptionalKeys, OptionalProps, Partial, PartialExcept, PartialOmit, PartialPick, Pick, Properties, RecordValue, RecursiveIntersect, RecursivePartial, RecursiveRequired, ReplaceProperty, Required, RequiredExcept, RequiredKeys, RequiredPick, Split, SpreadRecord, ValueOf, everyKey, facade, filterKey, findKey, forEachKey, getField, hasKey, hasProperty, mapKey, mapProperties, omit, pick, record, reduceByKey, reduceKey, replaceProperty, someKey, split, typeOverrideIncompatible.
+- [Primitives](https://cyberuni.github.io/type-plus/api/primitives/): 18 exports from `src/any/`, `src/never/`, `src/null/`, `src/symbol/`, `src/undefined/`, `src/unknown/`, `src/void/` -- HasNull, HasUndefined, HasVoid, IsAny, IsNever, IsNotAny, IsNotNever, IsNotNull, IsNotSymbol, IsNotUndefined, IsNotUnknown, IsNotVoid, IsNull, IsSymbol, IsUndefined, IsUnknown, IsVoid, NotUnknownOr.
+- [Promise](https://cyberuni.github.io/type-plus/api/promise/): 7 exports from `src/promise/` -- AwaitedProp, MaybePromise, PromiseValue, PromiseValueMerge, isPromise, mapSeries, transformMaybePromise.
+- [String](https://cyberuni.github.io/type-plus/api/string/): 10 exports from `src/string/` -- $ExtractManipulatedString, IsNotString, IsNotStringLiteral, IsNotTemplateLiteral, IsString, IsStringLiteral, IsTemplateLiteral, StringIncludes, StringPlus, StringSplit.
+- [Testing](https://cyberuni.github.io/type-plus/api/testing/): 2 exports from `src/testing/` -- stub, testType.
+- [Tuple](https://cyberuni.github.io/type-plus/api/tuple/): 14 exports from `src/tuple/` -- CommonPropKeys, CreateTuple, DropFirst, DropLast, DropMatch, DropNull, DropNullable, DropUndefined, IsNotTuple, IsTuple, Tail, ToTuple, TuplePlus, drop.
+- [Type branching](https://cyberuni.github.io/type-plus/api/type-branching/): 21 exports from `src/$type/` -- $Any, $Branch, $BranchOptions, $Distributive, $Else, $Error, $Exact, $InferError, $InputOptions, $MergeOptions, $Never, $NotNever, $ResolveBranch, $ResolveOptions, $Selection, $Special, $Then, $Type, $Unknown, Failed, FailedT.
+- [Type Guards and Assertions](https://cyberuni.github.io/type-plus/api/type-guards-and-assertions/): 15 exports from `src/assertion/`, `src/predicates/`, `src/type-guard/` -- Assignable, CanAssign, Extendable, If, IsAssign, IsEmptyObject, IsExtend, IsLiteral, IsNotExtend, NotAssignable, NotExtendable, StrictCanAssign, assertType, canAssign, isType.
+- [Union and Mixed Types](https://cyberuni.github.io/type-plus/api/union/): 8 exports from `src/mix_types/`, `src/union/` -- Box, Exclude, IsAnyOrNever, IsUnion, Merge, SubUnion, UnionType, merge.
+
+## Optional
+
+- [Source](https://github.com/cyberuni/type-plus/tree/main/packages/type-plus/src): the implementation, one symbol per file, named after the symbol.
+- [Undocumented families](https://github.com/cyberuni/type-plus/tree/main/packages/type-plus/src): 25 exports from `src/binary/`, `src/class/`, `src/nodejs/`, `src/`, `src/utils/` have no page on the site. Read their `.d.ts` directly: AnyConstructor, B, Bit, ComposableTypes, EitherAnd, EitherOrBoth, JSONArray, JSONObject, JSONPrimitive, JSONTypes, NoInfer, NonComposableTypes, PrimitiveTypes, SystemErrorCodes, SystemErrors, TypePlusOptions, UnionKeys, Widen, amend, as, asAny, inspect, isConstructor, isInstanceof, isSystemError.
+- [unpartial](https://www.npmjs.com/package/unpartial): re-exported wholesale, so `requiredDeep`, `required`, `unpartial` are documented there rather than here.

--- a/package.json
+++ b/package.json
@@ -8,6 +8,8 @@
 		"clean": "turbo run clean",
 		"coverage": "turbo run coverage",
 		"cs": "changeset",
+		"docs:llms": "node packages/type-plus/scripts/generate-llms-txt.mjs",
+		"docs:llms:check": "node packages/type-plus/scripts/generate-llms-txt.mjs --check",
 		"knip": "knip",
 		"format": "biome format .",
 		"k": "pnpm --filter ./packages/kind",
@@ -21,7 +23,7 @@
 		"test:type": "turbo run test:type",
 		"ttp": "turbo --filter type-plus",
 		"tp": "pnpm --filter type-plus",
-		"verify": "run-p check verify:pkg",
+		"verify": "run-p check docs:llms:check verify:pkg",
 		"verify:pkg": "turbo run test:type build verify:dts coverage size",
 		"version": "changeset version",
 		"web": "pnpm --filter website"

--- a/packages/type-plus/llms.txt
+++ b/packages/type-plus/llms.txt
@@ -1,0 +1,53 @@
+# type-plus
+
+> 273 utility types and functions for TypeScript, most of which resolve at the type level and emit no runtime code. This file is generated from the exported surface of `src/index.ts`; edit `packages/type-plus/scripts/generate-llms-txt.mjs`, not this file.
+
+Most of `type-plus` is types, not values. Importing a type costs nothing at runtime -- it is erased at compile time, and the shipped declarations are several times the size of the shipped JavaScript. Import types with `import type` and the rest with a plain `import`.
+
+## Conventions
+
+Four conventions govern almost every type in the library. Knowing them is worth more than knowing any individual symbol.
+
+- `Is*<T>` resolves to `true` or `false`. It resolves to `boolean` when `T` cannot be decided one way or the other -- `IsPositive<number>` is `boolean`, because `number` holds both positive and negative values. Every `Is*` type has a matching `IsNot*`.
+- `Is*<T, $O>` takes a second type parameter, an options object. `{ selection: 'filter' }` switches the result from a boolean to `T` itself (or `never` when the check fails), which makes the type usable as a filter over a union.
+- `{ distributive: false }` turns off distribution over unions. By default a check applied to `A | B` is applied to each member and the results are unioned; with distribution off the union is judged as a whole.
+- Every branch of a check is overridable through the same options object: `IsNever<any, { $any: 'any' }>`, and likewise `$unknown`, `$then` and `$else`. Passing the `Is*.$Branch` selector instead -- `IsNever<T, IsNever.$Branch>` -- yields the `$Then` / `$Else` markers, which is what makes a check composable inside another type.
+
+The authoritative, per-symbol detail is the TSDoc in the shipped `.d.ts` files, under `node_modules/type-plus/esm/`. 240 of the 273 exports carry TSDoc; the rest have a name and a signature only. A documented type states what it resolves to in `@example` blocks. Read the declaration before guessing at a signature. In `$type`, `math`, `object`, `predicates`, `string`, `tuple`, `union`, every documented example is pinned by a compiled test, so an example that drifts from the implementation fails to build.
+
+## Guides
+
+- [Getting Started](https://cyberuni.github.io/type-plus/guides/getting-started/): Install, import, and the first utility type.
+- [TypeScript Version Compatibility](https://cyberuni.github.io/type-plus/guides/typescript-version-compatibility/): Which TypeScript versions are supported and why the range matters for a type library.
+
+## Reference
+
+- [Type branching](https://cyberuni.github.io/type-plus/api/type-branching/): The `$Branch`, `$Then` and `$Else` mechanism in full.
+- [Options](https://cyberuni.github.io/type-plus/reference/options/): The `$Options` shapes shared across the library.
+- [Categories](https://cyberuni.github.io/type-plus/reference/categories/): What the category icons in the TSDoc mean.
+- [Status](https://cyberuni.github.io/type-plus/reference/status/): Stability and `@since` markers.
+
+## API
+
+- [Array](https://cyberuni.github.io/type-plus/api/array/): 21 exports from `src/array/` -- ArrayPlus, At, Concat, Filter, FindFirst, FindLast, Head, IntersectOfProps, IsArray, IsNotArray, KeepMatch, Last, MapToProp, PadStart, PropUnion, Reverse, Some, UnionOfProps, UnionOfValues, literalArray, reduceWhile.
+- [Boolean and Logical](https://cyberuni.github.io/type-plus/api/boolean/): 10 exports from `src/boolean/`, `src/logical/` -- And, IsBoolean, IsFalse, IsNotBoolean, IsNotFalse, IsNotTrue, IsTrue, Not, Or, Xor.
+- [Equality](https://cyberuni.github.io/type-plus/api/equality/): 6 exports from `src/equal/` -- $SelectInvert, $SelectInvertStrict, Equal, IsEqual, IsNotEqual, NotEqual.
+- [Function and Functional](https://cyberuni.github.io/type-plus/api/function/): 14 exports from `src/function/`, `src/functional/` -- AnyFunction, ChainFn, ContextBaseShape, ContextBuilder, ContextExtender, EndoFn, ExtractFunction, IsFunction, IsNotFunction, IsNotStrictFunction, IsStrictFunction, compose, context, extractFunction.
+- [Math and Bigint](https://cyberuni.github.io/type-plus/api/math/): 14 exports from `src/bigint/`, `src/math/` -- Abs, Add, Decrement, GreaterThan, Increment, IsBigint, IsBigintLiteral, IsNotBigint, IsNotBigintLiteral, MathPlus, Max, Multiply, StringToBigint, Subtract.
+- [Nominal Types](https://cyberuni.github.io/type-plus/api/nominal/): 8 exports from `src/nominal/` -- Brand, Branded, Flavor, Flavored, FlavoredUnit, brand, flavor, nominalMatch.
+- [Number and Numeric](https://cyberuni.github.io/type-plus/api/number/): 19 exports from `src/number/`, `src/numeric/` -- IsInteger, IsNegative, IsNotInteger, IsNotNegative, IsNotNumber, IsNotNumberLiteral, IsNotNumeric, IsNotPositive, IsNumber, IsNumberLiteral, IsNumeric, IsPositive, NumberPlus, Numeric, NumericPlus, NumericToString, StringToNumber, StringToNumeric, Zero.
+- [Object](https://cyberuni.github.io/type-plus/api/object/): 58 exports from `src/object/` -- ANotB, AdjustExactOptionalProps, AnyRecord, BNotA, Except, ExcludePropType, HasKey, IsDisjoint, IsNotObject, IsObject, IsOptionalKey, IsRecord, KeyTypes, KeysOfOptional, KeysWithDiffType, KnownKeys, LeftJoin, ObjectPlus, Omit, OptionalKeys, OptionalProps, Partial, PartialExcept, PartialOmit, PartialPick, Pick, Properties, RecordValue, RecursiveIntersect, RecursivePartial, RecursiveRequired, ReplaceProperty, Required, RequiredExcept, RequiredKeys, RequiredPick, Split, SpreadRecord, ValueOf, everyKey, facade, filterKey, findKey, forEachKey, getField, hasKey, hasProperty, mapKey, mapProperties, omit, pick, record, reduceByKey, reduceKey, replaceProperty, someKey, split, typeOverrideIncompatible.
+- [Primitives](https://cyberuni.github.io/type-plus/api/primitives/): 18 exports from `src/any/`, `src/never/`, `src/null/`, `src/symbol/`, `src/undefined/`, `src/unknown/`, `src/void/` -- HasNull, HasUndefined, HasVoid, IsAny, IsNever, IsNotAny, IsNotNever, IsNotNull, IsNotSymbol, IsNotUndefined, IsNotUnknown, IsNotVoid, IsNull, IsSymbol, IsUndefined, IsUnknown, IsVoid, NotUnknownOr.
+- [Promise](https://cyberuni.github.io/type-plus/api/promise/): 7 exports from `src/promise/` -- AwaitedProp, MaybePromise, PromiseValue, PromiseValueMerge, isPromise, mapSeries, transformMaybePromise.
+- [String](https://cyberuni.github.io/type-plus/api/string/): 10 exports from `src/string/` -- $ExtractManipulatedString, IsNotString, IsNotStringLiteral, IsNotTemplateLiteral, IsString, IsStringLiteral, IsTemplateLiteral, StringIncludes, StringPlus, StringSplit.
+- [Testing](https://cyberuni.github.io/type-plus/api/testing/): 2 exports from `src/testing/` -- stub, testType.
+- [Tuple](https://cyberuni.github.io/type-plus/api/tuple/): 14 exports from `src/tuple/` -- CommonPropKeys, CreateTuple, DropFirst, DropLast, DropMatch, DropNull, DropNullable, DropUndefined, IsNotTuple, IsTuple, Tail, ToTuple, TuplePlus, drop.
+- [Type branching](https://cyberuni.github.io/type-plus/api/type-branching/): 21 exports from `src/$type/` -- $Any, $Branch, $BranchOptions, $Distributive, $Else, $Error, $Exact, $InferError, $InputOptions, $MergeOptions, $Never, $NotNever, $ResolveBranch, $ResolveOptions, $Selection, $Special, $Then, $Type, $Unknown, Failed, FailedT.
+- [Type Guards and Assertions](https://cyberuni.github.io/type-plus/api/type-guards-and-assertions/): 15 exports from `src/assertion/`, `src/predicates/`, `src/type-guard/` -- Assignable, CanAssign, Extendable, If, IsAssign, IsEmptyObject, IsExtend, IsLiteral, IsNotExtend, NotAssignable, NotExtendable, StrictCanAssign, assertType, canAssign, isType.
+- [Union and Mixed Types](https://cyberuni.github.io/type-plus/api/union/): 8 exports from `src/mix_types/`, `src/union/` -- Box, Exclude, IsAnyOrNever, IsUnion, Merge, SubUnion, UnionType, merge.
+
+## Optional
+
+- [Source](https://github.com/cyberuni/type-plus/tree/main/packages/type-plus/src): the implementation, one symbol per file, named after the symbol.
+- [Undocumented families](https://github.com/cyberuni/type-plus/tree/main/packages/type-plus/src): 25 exports from `src/binary/`, `src/class/`, `src/nodejs/`, `src/`, `src/utils/` have no page on the site. Read their `.d.ts` directly: AnyConstructor, B, Bit, ComposableTypes, EitherAnd, EitherOrBoth, JSONArray, JSONObject, JSONPrimitive, JSONTypes, NoInfer, NonComposableTypes, PrimitiveTypes, SystemErrorCodes, SystemErrors, TypePlusOptions, UnionKeys, Widen, amend, as, asAny, inspect, isConstructor, isInstanceof, isSystemError.
+- [unpartial](https://www.npmjs.com/package/unpartial): re-exported wholesale, so `requiredDeep`, `required`, `unpartial` are documented there rather than here.

--- a/packages/type-plus/package.json
+++ b/packages/type-plus/package.json
@@ -46,6 +46,7 @@
   "types": "./esm/index.d.ts",
   "files": [
     "cjs",
+    "llms.txt",
     "esm",
     "src",
     "!**/*.{spec,test,unit,accept,integrate,system,perf,stress}.*"

--- a/packages/type-plus/scripts/generate-llms-txt.mjs
+++ b/packages/type-plus/scripts/generate-llms-txt.mjs
@@ -1,0 +1,332 @@
+// Usage: node scripts/generate-llms-txt.mjs [--check] [--undocumented]
+//
+// Generates `llms.txt` -- the orientation layer an agent needs before it can use
+// the 371 KB of `.d.ts` this package ships. The per-symbol detail already lives
+// in the declarations; what an agent meeting the library cold does not have is a
+// map: what the library is, the conventions that govern every type in it, and
+// which families exist.
+//
+// The family list, the symbol names and the counts are derived from the actual
+// exported type surface of `src/index.ts`, never hand-maintained. The repo has a
+// cautionary tale: the `src/**/readme.md` tree was hand-written, rotted into
+// documenting an API that no longer existed, and was deleted wholesale. A
+// hand-written `llms.txt` would rot exactly the same way.
+//
+// Flags:
+//   --check          exit non-zero if the files on disk differ from what this
+//                    script would write. Used by `pnpm docs:llms:check` in CI.
+//   --undocumented   print the exported-but-undocumented symbols as markdown
+//                    instead of writing anything. That list is the input for the
+//                    documentation-gap issue.
+//
+// The compiler API is taken from `ts-6.0` rather than `typescript`: the package
+// builds with TypeScript 7, whose npm package exposes only `version` to JS
+// consumers. `ts-6.0` is already a devDependency for the type tests.
+import { globSync, readFileSync, writeFileSync } from 'node:fs'
+import { dirname, join, relative } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import ts from 'ts-6.0'
+
+const packageRoot = join(dirname(fileURLToPath(import.meta.url)), '..')
+const repoRoot = join(packageRoot, '..', '..')
+const srcRoot = join(packageRoot, 'src')
+
+const SITE = 'https://cyberuni.github.io/type-plus'
+
+/** `console` is banned by the lint rules; this is a CLI script, so it writes directly. */
+function write(stream, message) {
+	stream.write(`${message}\n`)
+}
+
+/**
+ * Where each family of the type surface is documented on the site.
+ *
+ * `null` means "exported, but no page covers it" -- a real gap, reported rather
+ * than hidden. A family missing from this map is a hard error: a new directory
+ * under `src/` has to be pointed at a page or explicitly declared undocumented,
+ * so the map cannot silently fall behind the source.
+ */
+const FAMILY_DOCS = {
+	$type: { title: 'Type branching', page: 'api/type-branching' },
+	any: { title: 'Primitives', page: 'api/primitives' },
+	array: { title: 'Array', page: 'api/array' },
+	assertion: { title: 'Type Guards and Assertions', page: 'api/type-guards-and-assertions' },
+	bigint: { title: 'Math and Bigint', page: 'api/math' },
+	binary: null,
+	boolean: { title: 'Boolean and Logical', page: 'api/boolean' },
+	class: null,
+	equal: { title: 'Equality', page: 'api/equality' },
+	function: { title: 'Function and Functional', page: 'api/function' },
+	functional: { title: 'Function and Functional', page: 'api/function' },
+	logical: { title: 'Boolean and Logical', page: 'api/boolean' },
+	math: { title: 'Math and Bigint', page: 'api/math' },
+	mix_types: { title: 'Union and Mixed Types', page: 'api/union' },
+	never: { title: 'Primitives', page: 'api/primitives' },
+	nodejs: null,
+	nominal: { title: 'Nominal Types', page: 'api/nominal' },
+	null: { title: 'Primitives', page: 'api/primitives' },
+	number: { title: 'Number and Numeric', page: 'api/number' },
+	numeric: { title: 'Number and Numeric', page: 'api/number' },
+	object: { title: 'Object', page: 'api/object' },
+	predicates: { title: 'Type Guards and Assertions', page: 'api/type-guards-and-assertions' },
+	promise: { title: 'Promise', page: 'api/promise' },
+	root: null,
+	string: { title: 'String', page: 'api/string' },
+	symbol: { title: 'Primitives', page: 'api/primitives' },
+	testing: { title: 'Testing', page: 'api/testing' },
+	tuple: { title: 'Tuple', page: 'api/tuple' },
+	'type-guard': { title: 'Type Guards and Assertions', page: 'api/type-guards-and-assertions' },
+	undefined: { title: 'Primitives', page: 'api/primitives' },
+	union: { title: 'Union and Mixed Types', page: 'api/union' },
+	unknown: { title: 'Primitives', page: 'api/primitives' },
+	utils: null,
+	void: { title: 'Primitives', page: 'api/primitives' },
+}
+
+/**
+ * Families whose `@example` blocks are pinned to the implementation by a
+ * compiled `*_docs.spec.ts`. Read off disk rather than listed, so the claim can
+ * only be made about families that actually have one.
+ */
+function pinnedFamilies() {
+	return globSync('*/*_docs.spec.ts', { cwd: srcRoot })
+		.map((path) => path.slice(0, path.indexOf('/')))
+		.sort()
+}
+
+function pinnedNote(families) {
+	if (families.length === 0) return ''
+	const list = families.map((f) => `\`${f}\``).join(', ')
+	return ` In ${list}, every documented example is pinned by a compiled test, so an example that drifts from the implementation fails to build.`
+}
+
+/** Symbols re-exported from a dependency. Their docs are that package's job. */
+const EXTERNAL = 'external'
+
+function readExportSurface() {
+	const entry = join(srcRoot, 'index.ts')
+	const configFile = ts.readConfigFile(join(packageRoot, 'tsconfig.json'), ts.sys.readFile)
+	const parsed = ts.parseJsonConfigFileContent(configFile.config, ts.sys, packageRoot)
+	const program = ts.createProgram([entry], { ...parsed.options, noEmit: true })
+	const checker = program.getTypeChecker()
+	const moduleSymbol = checker.getSymbolAtLocation(program.getSourceFile(entry))
+
+	return checker.getExportsOfModule(moduleSymbol).map((symbol) => {
+		const target = symbol.flags & ts.SymbolFlags.Alias ? checker.getAliasedSymbol(symbol) : symbol
+		const fileName = target.declarations?.[0]?.getSourceFile().fileName ?? ''
+		const inPackage = fileName.startsWith(`${srcRoot}/`)
+		const path = inPackage ? relative(srcRoot, fileName) : fileName
+		return {
+			name: symbol.name,
+			family: inPackage ? (path.includes('/') ? path.slice(0, path.indexOf('/')) : 'root') : EXTERNAL,
+			documented: ts.displayPartsToString(target.getDocumentationComment(checker)).trim().length > 0,
+		}
+	})
+}
+
+function groupByFamily(exports) {
+	const families = new Map()
+	for (const item of exports) {
+		if (item.family === EXTERNAL) continue
+		if (!(item.family in FAMILY_DOCS)) {
+			throw new Error(
+				`src/${item.family}/ is not in FAMILY_DOCS. Point it at a docs page, or set it to \`null\` to declare it undocumented.`,
+			)
+		}
+		const bucket = families.get(item.family) ?? []
+		bucket.push(item)
+		families.set(item.family, bucket)
+	}
+	return families
+}
+
+/** One bullet per documented page, merging the families that share it. */
+function documentedSections(families) {
+	const pages = new Map()
+	for (const [family, items] of families) {
+		const doc = FAMILY_DOCS[family]
+		if (!doc) continue
+		const entry = pages.get(doc.page) ?? { title: doc.title, dirs: [], names: [] }
+		entry.dirs.push(family)
+		entry.names.push(...items.map((i) => i.name))
+		pages.set(doc.page, entry)
+	}
+	return [...pages]
+		.map(([page, entry]) => ({
+			page,
+			title: entry.title,
+			dirs: entry.dirs.sort(),
+			names: [...new Set(entry.names)].sort(),
+		}))
+		.sort((a, b) => a.title.localeCompare(b.title))
+}
+
+function undocumentedFamilies(families) {
+	return [...families]
+		.filter(([family]) => FAMILY_DOCS[family] === null)
+		.map(([family, items]) => ({ family, names: items.map((i) => i.name).sort() }))
+		.sort((a, b) => a.family.localeCompare(b.family))
+}
+
+function undocumentedSymbols(exports) {
+	return exports
+		.filter((item) => !item.documented && item.family !== EXTERNAL)
+		.sort((a, b) => {
+			return a.family.localeCompare(b.family) || a.name.localeCompare(b.name)
+		})
+}
+
+function bullet(title, page, note) {
+	return `- [${title}](${SITE}/${page}/): ${note}`
+}
+
+function renderLlmsTxt(exports) {
+	const families = groupByFamily(exports)
+	const sections = documentedSections(families)
+	const gaps = undocumentedFamilies(families)
+	const missingDocs = undocumentedSymbols(exports)
+	const external = exports.filter((item) => item.family === EXTERNAL)
+	const total = exports.length
+	const documented = total - missingDocs.length - external.length
+
+	const lines = []
+	lines.push('# type-plus')
+	lines.push('')
+	lines.push(
+		`> ${total} utility types and functions for TypeScript, most of which resolve at the type level and emit no runtime code. This file is generated from the exported surface of \`src/index.ts\`; edit \`packages/type-plus/scripts/generate-llms-txt.mjs\`, not this file.`,
+	)
+	lines.push('')
+	lines.push(
+		'Most of `type-plus` is types, not values. Importing a type costs nothing at runtime -- it is erased at compile time, and the shipped declarations are several times the size of the shipped JavaScript. Import types with `import type` and the rest with a plain `import`.',
+	)
+	lines.push('')
+	lines.push('## Conventions')
+	lines.push('')
+	lines.push(
+		'Four conventions govern almost every type in the library. Knowing them is worth more than knowing any individual symbol.',
+	)
+	lines.push('')
+	lines.push(
+		'- `Is*<T>` resolves to `true` or `false`. It resolves to `boolean` when `T` cannot be decided one way or the other -- `IsPositive<number>` is `boolean`, because `number` holds both positive and negative values. Every `Is*` type has a matching `IsNot*`.',
+	)
+	lines.push(
+		"- `Is*<T, $O>` takes a second type parameter, an options object. `{ selection: 'filter' }` switches the result from a boolean to `T` itself (or `never` when the check fails), which makes the type usable as a filter over a union.",
+	)
+	lines.push(
+		'- `{ distributive: false }` turns off distribution over unions. By default a check applied to `A | B` is applied to each member and the results are unioned; with distribution off the union is judged as a whole.',
+	)
+	lines.push(
+		"- Every branch of a check is overridable through the same options object: `IsNever<any, { $any: 'any' }>`, and likewise `$unknown`, `$then` and `$else`. Passing the `Is*.$Branch` selector instead -- `IsNever<T, IsNever.$Branch>` -- yields the `$Then` / `$Else` markers, which is what makes a check composable inside another type.",
+	)
+	lines.push('')
+	lines.push(
+		`The authoritative, per-symbol detail is the TSDoc in the shipped \`.d.ts\` files, under \`node_modules/type-plus/esm/\`. ${documented} of the ${total} exports carry TSDoc; the rest have a name and a signature only. A documented type states what it resolves to in \`@example\` blocks. Read the declaration before guessing at a signature.${pinnedNote(pinnedFamilies())}`,
+	)
+	lines.push('')
+	lines.push('## Guides')
+	lines.push('')
+	lines.push(bullet('Getting Started', 'guides/getting-started', 'Install, import, and the first utility type.'))
+	lines.push(
+		bullet(
+			'TypeScript Version Compatibility',
+			'guides/typescript-version-compatibility',
+			'Which TypeScript versions are supported and why the range matters for a type library.',
+		),
+	)
+	lines.push('')
+	lines.push('## Reference')
+	lines.push('')
+	lines.push(bullet('Type branching', 'api/type-branching', 'The `$Branch`, `$Then` and `$Else` mechanism in full.'))
+	lines.push(bullet('Options', 'reference/options', 'The `$Options` shapes shared across the library.'))
+	lines.push(bullet('Categories', 'reference/categories', 'What the category icons in the TSDoc mean.'))
+	lines.push(bullet('Status', 'reference/status', 'Stability and `@since` markers.'))
+	lines.push('')
+	lines.push('## API')
+	lines.push('')
+	for (const section of sections) {
+		lines.push(
+			bullet(
+				section.title,
+				section.page,
+				`${section.names.length} exports from ${section.dirs.map((d) => `\`src/${d}/\``).join(', ')} -- ${section.names.join(', ')}.`,
+			),
+		)
+	}
+	lines.push('')
+	lines.push('## Optional')
+	lines.push('')
+	lines.push(
+		'- [Source](https://github.com/cyberuni/type-plus/tree/main/packages/type-plus/src): the implementation, one symbol per file, named after the symbol.',
+	)
+	if (gaps.length > 0) {
+		const count = gaps.reduce((sum, gap) => sum + gap.names.length, 0)
+		lines.push(
+			`- [Undocumented families](https://github.com/cyberuni/type-plus/tree/main/packages/type-plus/src): ${count} exports from ${gaps.map((g) => `\`src/${g.family === 'root' ? '' : `${g.family}/`}\``).join(', ')} have no page on the site. Read their \`.d.ts\` directly: ${gaps
+				.flatMap((g) => g.names)
+				.sort()
+				.join(', ')}.`,
+		)
+	}
+	if (external.length > 0) {
+		lines.push(
+			`- [unpartial](https://www.npmjs.com/package/unpartial): re-exported wholesale, so ${external
+				.map((e) => `\`${e.name}\``)
+				.sort()
+				.join(', ')} are documented there rather than here.`,
+		)
+	}
+	lines.push('')
+	return lines.join('\n')
+}
+
+function renderUndocumentedReport(exports) {
+	const missing = undocumentedSymbols(exports)
+	const byFamily = new Map()
+	for (const item of missing) {
+		byFamily.set(item.family, [...(byFamily.get(item.family) ?? []), item.name])
+	}
+	const lines = [
+		`${missing.length} of ${exports.length} exported symbols have no TSDoc comment.`,
+		'',
+		'| Family | Undocumented exports |',
+		'| --- | --- |',
+	]
+	for (const [family, names] of [...byFamily].sort((a, b) => a[0].localeCompare(b[0]))) {
+		lines.push(`| \`src/${family === 'root' ? '' : `${family}/`}\` | ${names.map((n) => `\`${n}\``).join(', ')} |`)
+	}
+	return lines.join('\n')
+}
+
+const targets = [join(packageRoot, 'llms.txt'), join(repoRoot, 'apps', 'website', 'public', 'llms.txt')]
+
+const args = process.argv.slice(2)
+const exportSurface = readExportSurface()
+
+if (args.includes('--undocumented')) {
+	write(process.stdout, renderUndocumentedReport(exportSurface))
+} else {
+	const content = renderLlmsTxt(exportSurface)
+	if (args.includes('--check')) {
+		const stale = targets.filter((target) => {
+			try {
+				return readFileSync(target, 'utf8') !== content
+			} catch {
+				return true
+			}
+		})
+		if (stale.length > 0) {
+			write(
+				process.stderr,
+				`llms.txt is out of date:\n${stale.map((t) => `  ${relative(repoRoot, t)}`).join('\n')}\nRun \`pnpm docs:llms\` and commit the result.`,
+			)
+			process.exit(1)
+		}
+		write(process.stdout, 'llms.txt is up to date.')
+	} else {
+		for (const target of targets) writeFileSync(target, content)
+		write(
+			process.stdout,
+			`Wrote llms.txt (${exportSurface.length} exports):\n${targets.map((t) => `  ${relative(repoRoot, t)}`).join('\n')}`,
+		)
+	}
+}

--- a/packages/type-plus/src/llms_txt.spec.ts
+++ b/packages/type-plus/src/llms_txt.spec.ts
@@ -1,0 +1,19 @@
+/**
+ * Pins the conventions stated in `llms.txt` to the implementation.
+ *
+ * `llms.txt` is the orientation layer an agent reads before touching the
+ * `.d.ts`. Its per-family content is derived from the export surface, but the
+ * conventions it explains are prose in `scripts/generate-llms-txt.mjs`; these
+ * assertions are what stop that prose from drifting.
+ */
+import { it } from 'vitest'
+import { type $Else, type $Then, type IsNever, type IsPositive, type IsString, testType } from './index.js'
+
+it('llms.txt conventions', () => {
+	testType.equal<IsPositive<number>, boolean>(true)
+	testType.equal<IsString<string | 1, { selection: 'filter' }>, string>(true)
+	testType.equal<IsString<string | 1, { distributive: false }>, false>(true)
+	testType.equal<IsNever<any, { $any: 'any' }>, 'any'>(true)
+	testType.equal<IsNever<never, IsNever.$Branch>, $Then>(true)
+	testType.equal<IsNever<1, IsNever.$Branch>, $Else>(true)
+})


### PR DESCRIPTION
## What

Adds `llms.txt` — an orientation layer for agents and LLMs reading this library — generated from the actual exported type surface.

- `packages/type-plus/scripts/generate-llms-txt.mjs` — the generator.
- `packages/type-plus/llms.txt` and `apps/website/public/llms.txt` — its two outputs.
- `packages/type-plus/src/llms_txt.spec.ts` — pins the conventions the file states.
- `pnpm docs:llms` regenerates; `pnpm docs:llms:check` fails when the checked-in copies drift, and now runs as part of `pnpm verify`, which is what CI runs.

## Why

`type-plus` is a type-level library, and what an agent needs to know is what a type *resolves to*. That already lives in the TSDoc, which is the right channel: re-measured on `main` at `db936ad`, the shipped ESM JavaScript is 38 KB while the shipped `.d.ts` is 428 KB, and 649 comment lines survive into the emitted `.js` versus 7,163 in the declarations. The docs are attached to types, so they are erased from the JS emit — documenting heavily there costs consumers nothing.

(Those figures moved materially in a week — #672, #673 and #674 grew the declarations while the runtime output barely changed. Which is why the generated file states no byte counts of its own.)

What is missing is the map. An agent meeting the library cold has 371 KB of declarations and no way in. `llms.txt` gives it the four conventions that govern nearly every type (`Is*`, `{ selection: 'filter' }`, `{ distributive: false }`, the branch options and `$Branch` selectors), the family list, and where the per-symbol detail lives. It deliberately does not restate the per-symbol detail — the agent already has that.

## Why generated

This repo has the cautionary tale on file. The `src/**/readme.md` tree was hand-maintained, rotted into documenting an API that no longer exists (`Positive<T>`, `StringType`, `IsStrictNumber`), and 13 of those files were deleted in #667. A hand-written `llms.txt` rots the same way.

So the family list, symbol names and counts are read from `src/index.ts` through the compiler API, not typed by hand. Two further guards:

- A directory under `src/` that is not in the generator's `FAMILY_DOCS` map is a **hard error**, not a silent omission. A new family has to be pointed at a docs page or explicitly declared undocumented.
- The "these families have their examples pinned by compiled tests" sentence is emitted only for families that actually have a `*_docs.spec.ts` on disk, so it cannot over-claim.

The conventions section is genuinely prose — it is judgement, not data — so `src/llms_txt.spec.ts` asserts each claim it makes with `testType.equal`. If `IsPositive<number>` stops being `boolean`, the build fails.

The generator uses the compiler API from `ts-6.0` rather than `typescript`. The package now builds with TypeScript 7, whose npm package exposes only `version` to JS consumers; `ts-6.0` is already a devDependency for the type tests.

## Shipping decision: both `files` and the website

`llms.txt` is listed in `files`, so it lands at `node_modules/type-plus/llms.txt`, and it is also served from `https://cyberuni.github.io/type-plus/llms.txt`.

The argument for `node_modules`: the agent that needs orientation is, by definition, the one sitting in front of the installed package with 371 KB of `.d.ts`. It has `node_modules`; it may not have the web. Shipping the map next to the thing it maps is the whole point. The cost is ~5 KB on a package that already ships 371 KB of declarations — under 2%.

The argument for the website: `llms.txt` is a web convention (llmstxt.org), and the links in it are absolute URLs into the docs site. Anything fetching `/llms.txt` for the project expects it there.

Both copies are generated from the same function and both are covered by the drift check, so they cannot diverge.

## Follow-up filed

Generating from the type surface is what makes the documentation gap visible. `node scripts/generate-llms-txt.mjs --undocumented` reports the exports with no TSDoc at all, plus the families with no page on the site (`src/binary/`, `src/class/`, `src/nodejs/`, `src/utils/`, and the root files) — including live APIs whose only surviving documentation was the `info.md` deleted in #667: `JSONTypes`, `nominalMatch`.

Filed as #669. When that issue was opened the count was 88 of 276; #672, #673 and #674 have since taken it to **30 of 273**, and this PR's regenerated `llms.txt` states the current figure rather than the one from the day it was written — which is the point of generating it.

Writing the remaining docs is a separate body of work and this PR does not attempt it.

## Notes on conflicts

Touches `package.json` (root), `packages/type-plus/package.json` (`files` only), and adds new files. It touches no `src/**` type source and no page under `apps/website/src/content/docs/`, so it does not collide with any other work in flight.

Rebased onto `main` after #658, #659, #660, #661, #662, #663, #664, #671, #672, #673 and #674 landed, and `llms.txt` regenerated on top of them. The regeneration is itself the demonstration: the retired `LooseArrayType` family and `CommonKeys` dropped out on their own, `HasNull`/`HasVoid` appeared, the documented count moved from 185/276 to 240/273, and the "examples are pinned by compiled tests" sentence switched itself on now that seven families have a `*_docs.spec.ts`. Nothing in that paragraph was edited by hand.

## Verification

`pnpm -w turbo build lint test`, `pnpm --filter type-plus test:type` (5.4 / 5.5 / 5.6 / 6.0 / 7) and `pnpm run verify:pkg` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BUybspzGX8c3w7u3egBTQp


