### PR TITLE
docs(type-plus): pin the string, object, tuple and union examples

### DIFF
--- a/.changeset/lucky-donkeys-pin.md
+++ b/.changeset/lucky-donkeys-pin.md
@@ -1,0 +1,33 @@
+---
+'type-plus': patch
+---
+
+Correct the TSDoc for the `string`, `object`, `tuple` and `union` types, and pin every documented
+example to the implementation.
+
+Twenty-four documented claims did not match what the types actually resolve to:
+
+- `IsNotString<never>` and `IsNotString<unknown>` were documented as `false`; the special types are
+  not strings, so the negation accepts them and both are `true`. `IsNotString<string | 1, {
+  distributive: false }>` was documented as `false` and is `true`.
+- `IsStringLiteral` and `IsNotStringLiteral` illustrated the `exact` option with `'${number}'`, an
+  ordinary string literal, where the template literal `` `${number}` `` was meant.
+- `IsObject`'s first example asserted `IsNotObject<object> // true` — the wrong type, and the wrong
+  answer for it. The `{ selection: 'filter' }` examples for `IsObject`, `IsNotObject` and
+  `IsNotTuple` were missing the option they were demonstrating.
+- `DropLast<[1, 2, 3]>` was documented as `[2, 3]`, copied from `DropFirst`; it is `[1, 2]`.
+- `IsNotTuple<[] | 1, { distributive: false }>` was documented as `false` and is `true`.
+- `TuplePlus.Find<[true, number | string], string>` was documented as `string | undefined`;
+  `$unionNotMatch` defaults to `never`, so it is `string`. The example now shows both.
+- `TuplePlus.Filter`'s examples were written as bare `Filter`, which resolves to the unrelated
+  array `Filter`, and `UnionType`'s examples were written as `IsUnion`.
+- The branch examples used names that do not exist — `$IsString.$Branch`, `$IsNotStringLiteral.$Branch`
+  and the retired `$SelectionBranch` — and two of them named `IsString` in `IsTemplateLiteral`'s docs.
+
+On the docs site, `$ExtractManipulatedString<Uppercase<'abc'>>` was documented as `'abc'`. The
+intrinsic resolves before the type sees it, so the result is `'ABC'`; only an unresolved intrinsic
+can be seen through.
+
+`src/string/string_docs.spec.ts`, `src/object/object_docs.spec.ts`, `src/tuple/tuple_docs.spec.ts`
+and `src/union/union_docs.spec.ts` now pin every documented example with `testType.equal`, so an
+example that drifts from the implementation fails to compile.

--- a/apps/website/src/content/docs/api/string.md
+++ b/apps/website/src/content/docs/api/string.md
@@ -138,9 +138,13 @@ A type util (the `$` prefix marks it as building material rather than an everyda
 intrinsic string manipulation types — `Uppercase`, `Lowercase`, `Capitalize` and `Uncapitalize` — to
 recover the string being manipulated. `IsStringLiteral` uses it to see through those wrappers.
 
+It only sees a wrapper that TypeScript has not already resolved. Applied to a literal, the intrinsic
+evaluates first and there is nothing left to unwrap:
+
 ```ts
-type R1 = $ExtractManipulatedString<Uppercase<'abc'>> // 'abc'
-type R2 = $ExtractManipulatedString<'abc'> // 'abc'
+type R1 = $ExtractManipulatedString<Uppercase<string>> // string
+type R2 = $ExtractManipulatedString<Uppercase<'abc'>> // 'ABC'
+type R3 = $ExtractManipulatedString<'abc'> // 'abc'
 ```
 
 ## Reference

--- a/packages/type-plus/src/object/is_not_object.ts
+++ b/packages/type-plus/src/object/is_not_object.ts
@@ -61,7 +61,7 @@ import type { NotAssignable } from '../predicates/not_assignable.js'
  * type R = IsNotObject<never, { selection: 'filter' }> // never
  * type R = IsNotObject<unknown, { selection: 'filter' }> // unknown
  *
- * type R = IsNotObject<{} | bigint> // bigint
+ * type R = IsNotObject<{} | bigint, { selection: 'filter' }> // bigint
  * ```
  *
  * 🔢 *customize*:
@@ -89,8 +89,8 @@ import type { NotAssignable } from '../predicates/not_assignable.js'
  *
  * @example
  * ```ts
- * type R = IsNotObject<{}, $SelectionBranch> // $Else
- * type R = IsNotObject<string, $SelectionBranch> // $Then
+ * type R = IsNotObject<{}, IsNotObject.$Branch> // $Else
+ * type R = IsNotObject<string, IsNotObject.$Branch> // $Then
  * ```
  */
 export type IsNotObject<T, $O extends IsNotObject.$Options = {}> = $Special<

--- a/packages/type-plus/src/object/is_object.ts
+++ b/packages/type-plus/src/object/is_object.ts
@@ -23,7 +23,7 @@ import type { Assignable } from '../predicates/assignable.js'
  *
  * @example
  * ```ts
- * type R = IsNotObject<object> // true
+ * type R = IsObject<object> // true
  * type R = IsObject<{}> // true
  * type R = IsObject<{ a: 1 }> // true
  * type R = IsObject<Function> // true
@@ -48,7 +48,7 @@ import type { Assignable } from '../predicates/assignable.js'
  * type R = IsObject<never, { selection: 'filter' }> // never
  * type R = IsObject<unknown, { selection: 'filter' }> // never
  *
- * type R = IsObject<{} | bigint> // {}
+ * type R = IsObject<{} | bigint, { selection: 'filter' }> // {}
  * ```
  *
  * 🔢 *customize*:
@@ -76,8 +76,8 @@ import type { Assignable } from '../predicates/assignable.js'
  *
  * @example
  * ```ts
- * type R = IsObject<{}, $SelectionBranch> // $Then
- * type R = IsObject<string, $SelectionBranch> // $Else
+ * type R = IsObject<{}, IsObject.$Branch> // $Then
+ * type R = IsObject<string, IsObject.$Branch> // $Else
  * ```
  */
 export type IsObject<T, $O extends IsObject.$Options = {}> = $Special<

--- a/packages/type-plus/src/object/object_docs.spec.ts
+++ b/packages/type-plus/src/object/object_docs.spec.ts
@@ -1,0 +1,64 @@
+/**
+ * Pins the `@example` blocks in the `src/object/*.ts` TSDoc comments to the
+ * actual behavior.
+ *
+ * Every assertion here mirrors a line documented in `src/object/*.ts`, so a doc
+ * example that drifts from the implementation fails to compile.
+ *
+ * Follows the pattern introduced for the numeric family in #662.
+ */
+import { it } from 'vitest'
+
+import { type $Else, type $Then, type IsNotObject, type IsObject, type Properties, testType } from '../index.js'
+
+it('IsObject examples in TSDoc are accurate', () => {
+	testType.equal<IsObject<object>, true>(true)
+	testType.equal<IsObject<{}>, true>(true)
+	testType.equal<IsObject<{ a: 1 }>, true>(true)
+	testType.equal<IsObject<Function>, true>(true)
+	testType.equal<IsObject<never>, false>(true)
+	testType.equal<IsObject<unknown>, false>(true)
+	testType.equal<IsObject<number>, false>(true)
+	testType.equal<IsObject<{} | bigint>, boolean>(true)
+	testType.equal<IsObject<{}, { selection: 'filter' }>, {}>(true)
+	testType.equal<IsObject<{ a: 1 }, { selection: 'filter' }>, { a: 1 }>(true)
+	testType.equal<IsObject<Function, { selection: 'filter' }>, Function>(true)
+	testType.equal<IsObject<never, { selection: 'filter' }>, never>(true)
+	testType.equal<IsObject<unknown, { selection: 'filter' }>, never>(true)
+	testType.equal<IsObject<{} | bigint, { selection: 'filter' }>, {}>(true)
+	testType.equal<IsObject<object, { exact: true }>, true>(true)
+	testType.equal<IsObject<{}, { exact: true }>, false>(true)
+	testType.equal<IsObject<{} | 1>, boolean>(true)
+	testType.equal<IsObject<{} | 1, { distributive: false }>, false>(true)
+	testType.equal<IsObject<{}, IsObject.$Branch>, $Then>(true)
+	testType.equal<IsObject<string, IsObject.$Branch>, $Else>(true)
+})
+
+it('IsNotObject examples in TSDoc are accurate', () => {
+	testType.equal<IsNotObject<{}>, false>(true)
+	testType.equal<IsNotObject<{ a: 1 }>, false>(true)
+	testType.equal<IsNotObject<Function>, false>(true)
+	testType.equal<IsNotObject<number>, true>(true)
+	testType.equal<IsNotObject<object>, false>(true)
+	testType.equal<IsNotObject<never>, true>(true)
+	testType.equal<IsNotObject<unknown>, true>(true)
+	testType.equal<IsNotObject<{} | bigint>, boolean>(true)
+	testType.equal<IsNotObject<{}, { selection: 'filter' }>, never>(true)
+	testType.equal<IsNotObject<{ a: 1 }, { selection: 'filter' }>, never>(true)
+	testType.equal<IsNotObject<Function, { selection: 'filter' }>, never>(true)
+	testType.equal<IsNotObject<never, { selection: 'filter' }>, never>(true)
+	testType.equal<IsNotObject<unknown, { selection: 'filter' }>, unknown>(true)
+	testType.equal<IsNotObject<{} | bigint, { selection: 'filter' }>, bigint>(true)
+	testType.equal<IsNotObject<object, { exact: true }>, false>(true)
+	testType.equal<IsNotObject<{}, { exact: true }>, true>(true)
+	testType.equal<IsNotObject<{} | 1>, boolean>(true)
+	testType.equal<IsNotObject<{} | 1, { distributive: false }>, true>(true)
+	testType.equal<IsNotObject<{}, IsNotObject.$Branch>, $Else>(true)
+	testType.equal<IsNotObject<string, IsNotObject.$Branch>, $Then>(true)
+})
+
+it('Properties examples in TSDoc are accurate', () => {
+	type T = { a: number; b?: string }
+	testType.equal<Properties<T>, { a: number; b?: string }>(true)
+	testType.equal<Properties<{ a: 1 } & { b: 2 }>, { a: 1; b: 2 }>(true)
+})

--- a/packages/type-plus/src/string/is_not_string.ts
+++ b/packages/type-plus/src/string/is_not_string.ts
@@ -22,8 +22,8 @@ import type { NotAssignable } from '../predicates/not_assignable.js'
  * type R = IsNotString<string> // false
  * type R = IsNotString<'a'> // false
  *
- * type R = IsNotString<never> // false
- * type R = IsNotString<unknown> // false
+ * type R = IsNotString<never> // true
+ * type R = IsNotString<unknown> // true
  * type R = IsNotString<string | boolean> // boolean
  * ```
  *
@@ -47,7 +47,7 @@ import type { NotAssignable } from '../predicates/not_assignable.js'
  *
  * ```ts
  * type R = IsNotString<string | 1> // boolean
- * type R = IsNotString<string | 1, { distributive: false }> // false
+ * type R = IsNotString<string | 1, { distributive: false }> // true
  * ```
  *
  * 🔢 *customize*
@@ -56,8 +56,8 @@ import type { NotAssignable } from '../predicates/not_assignable.js'
  *
  * @example
  * ```ts
- * type R = IsNotString<string, $IsNotString.$Branch> // $Else
- * type R = IsNotString<bigint, $IsNotString.$Branch> // $Then
+ * type R = IsNotString<string, IsNotString.$Branch> // $Else
+ * type R = IsNotString<bigint, IsNotString.$Branch> // $Then
  * ```
  */
 export type IsNotString<T, $O extends IsNotString.$Options = {}> = $Special<

--- a/packages/type-plus/src/string/is_not_string_literal.ts
+++ b/packages/type-plus/src/string/is_not_string_literal.ts
@@ -57,8 +57,8 @@ import type { _StringType } from './_string_type.js'
  * Check if `T` is exactly not a string literal, excluding template literals.
  *
  * ```ts
- * type R = IsNotStringLiteral<'${number}'> // false
- * type R = IsNotStringLiteral<'${number}', { exact: true }> // true
+ * type R = IsNotStringLiteral<`${number}`> // false
+ * type R = IsNotStringLiteral<`${number}`, { exact: true }> // true
  * ```
  *
  * 🔢 *customize*
@@ -67,8 +67,8 @@ import type { _StringType } from './_string_type.js'
  *
  * @example
  * ```ts
- * type R = IsNotStringLiteral<'abc', $IsNotStringLiteral.$Branch> // $Else
- * type R = IsNotStringLiteral<string, $IsNotStringLiteral.$Branch> // $Then
+ * type R = IsNotStringLiteral<'abc', IsNotStringLiteral.$Branch> // $Else
+ * type R = IsNotStringLiteral<string, IsNotStringLiteral.$Branch> // $Then
  * ```
  */
 export type IsNotStringLiteral<T, $O extends IsNotStringLiteral.$Options = {}> = $Special<

--- a/packages/type-plus/src/string/is_not_template_literal.ts
+++ b/packages/type-plus/src/string/is_not_template_literal.ts
@@ -53,8 +53,8 @@ import type { _StringType } from './_string_type.js'
  *
  * @example
  * ```ts
- * type R = IsNotTemplateLiteral<`${number}`, $IsNotTemplateLiteral.$Branch> // $Else
- * type R = IsNotTemplateLiteral<bigint, $IsString.$Branch> // $Then
+ * type R = IsNotTemplateLiteral<`${number}`, IsNotTemplateLiteral.$Branch> // $Else
+ * type R = IsNotTemplateLiteral<bigint, IsNotTemplateLiteral.$Branch> // $Then
  * ```
  */
 export type IsNotTemplateLiteral<T, $O extends IsNotTemplateLiteral.$Options = {}> = $Special<

--- a/packages/type-plus/src/string/is_string.ts
+++ b/packages/type-plus/src/string/is_string.ts
@@ -56,8 +56,8 @@ import type { Assignable } from '../predicates/assignable.js'
  *
  * @example
  * ```ts
- * type R = IsString<string, $IsString.$Branch> // $Then
- * type R = IsString<bigint, $IsString.$Branch> // $Else
+ * type R = IsString<string, IsString.$Branch> // $Then
+ * type R = IsString<bigint, IsString.$Branch> // $Else
  * ```
  */
 export type IsString<T, $O extends IsString.$Options = {}> = $Special<

--- a/packages/type-plus/src/string/is_string_literal.ts
+++ b/packages/type-plus/src/string/is_string_literal.ts
@@ -57,8 +57,8 @@ import type { _StringType } from './_string_type.js'
  * Check if `T` is exactly a string literal, excluding template literals.
  *
  * ```ts
- * type R = IsStringLiteral<'${number}'> // true
- * type R = IsStringLiteral<'${number}', { exact: true }> // false
+ * type R = IsStringLiteral<`${number}`> // true
+ * type R = IsStringLiteral<`${number}`, { exact: true }> // false
  * ```
  *
  * 🔢 *customize*
@@ -67,8 +67,8 @@ import type { _StringType } from './_string_type.js'
  *
  * @example
  * ```ts
- * type R = IsStringLiteral<'abc', $IsStringLiteral.$Branch> // $Then
- * type R = IsStringLiteral<string, $IsStringLiteral.$Branch> // $Else
+ * type R = IsStringLiteral<'abc', IsStringLiteral.$Branch> // $Then
+ * type R = IsStringLiteral<string, IsStringLiteral.$Branch> // $Else
  * ```
  */
 export type IsStringLiteral<T, $O extends IsStringLiteral.$Options = {}> = $Special<

--- a/packages/type-plus/src/string/is_template_literal.ts
+++ b/packages/type-plus/src/string/is_template_literal.ts
@@ -55,8 +55,8 @@ import type { _StringType } from './_string_type.js'
  *
  * @example
  * ```ts
- * type R = IsTemplateLiteral<`${number}`, $IsTemplateLiteral.$Branch> // $Then
- * type R = IsTemplateLiteral<bigint, $IsString.$Branch> // $Else
+ * type R = IsTemplateLiteral<`${number}`, IsTemplateLiteral.$Branch> // $Then
+ * type R = IsTemplateLiteral<bigint, IsTemplateLiteral.$Branch> // $Else
  * ```
  */
 export type IsTemplateLiteral<T, $O extends IsTemplateLiteral.$Options = {}> = $Special<

--- a/packages/type-plus/src/string/string_docs.spec.ts
+++ b/packages/type-plus/src/string/string_docs.spec.ts
@@ -1,0 +1,155 @@
+/**
+ * Pins the `@example` blocks in the `src/string/*.ts` TSDoc comments to the
+ * actual behavior.
+ *
+ * Every assertion here mirrors a line documented in `src/string/*.ts`, so a doc
+ * example that drifts from the implementation fails to compile.
+ *
+ * Follows the pattern introduced for the numeric family in #662.
+ */
+import { it } from 'vitest'
+
+import {
+	type $Else,
+	type $ExtractManipulatedString,
+	type $Then,
+	type IsNotString,
+	type IsNotStringLiteral,
+	type IsNotTemplateLiteral,
+	type IsString,
+	type IsStringLiteral,
+	type IsTemplateLiteral,
+	type StringIncludes,
+	type StringPlus,
+	type StringSplit,
+	testType,
+} from '../index.js'
+
+it('IsString examples in TSDoc are accurate', () => {
+	testType.equal<IsString<string>, true>(true)
+	testType.equal<IsString<'a'>, true>(true)
+	testType.equal<IsString<never>, false>(true)
+	testType.equal<IsString<unknown>, false>(true)
+	testType.equal<IsString<string | boolean>, boolean>(true)
+	testType.equal<IsString<string, { selection: 'filter' }>, string>(true)
+	testType.equal<IsString<'a', { selection: 'filter' }>, 'a'>(true)
+	testType.equal<IsString<never, { selection: 'filter' }>, never>(true)
+	testType.equal<IsString<unknown, { selection: 'filter' }>, never>(true)
+	testType.equal<IsString<string | boolean, { selection: 'filter' }>, string>(true)
+	testType.equal<IsString<string | 1>, boolean>(true)
+	testType.equal<IsString<string | 1, { distributive: false }>, false>(true)
+	testType.equal<IsString<string, IsString.$Branch>, $Then>(true)
+	testType.equal<IsString<bigint, IsString.$Branch>, $Else>(true)
+})
+
+it('IsNotString examples in TSDoc are accurate', () => {
+	testType.equal<IsNotString<string>, false>(true)
+	testType.equal<IsNotString<'a'>, false>(true)
+	testType.equal<IsNotString<never>, true>(true)
+	testType.equal<IsNotString<unknown>, true>(true)
+	testType.equal<IsNotString<string | boolean>, boolean>(true)
+	testType.equal<IsNotString<string, { selection: 'filter' }>, never>(true)
+	testType.equal<IsNotString<'a', { selection: 'filter' }>, never>(true)
+	testType.equal<IsNotString<never, { selection: 'filter' }>, never>(true)
+	testType.equal<IsNotString<unknown, { selection: 'filter' }>, unknown>(true)
+	testType.equal<IsNotString<string | boolean, { selection: 'filter' }>, boolean>(true)
+	testType.equal<IsNotString<string | 1>, boolean>(true)
+	testType.equal<IsNotString<string | 1, { distributive: false }>, true>(true)
+	testType.equal<IsNotString<string, IsNotString.$Branch>, $Else>(true)
+	testType.equal<IsNotString<bigint, IsNotString.$Branch>, $Then>(true)
+})
+
+it('IsStringLiteral examples in TSDoc are accurate', () => {
+	testType.equal<IsStringLiteral<string>, false>(true)
+	testType.equal<IsStringLiteral<'a'>, true>(true)
+	testType.equal<IsStringLiteral<`${number}`>, true>(true)
+	testType.equal<IsStringLiteral<never>, false>(true)
+	testType.equal<IsStringLiteral<unknown>, false>(true)
+	testType.equal<IsStringLiteral<'a' | boolean>, boolean>(true)
+	testType.equal<IsStringLiteral<string, { selection: 'filter' }>, never>(true)
+	testType.equal<IsStringLiteral<'a', { selection: 'filter' }>, 'a'>(true)
+	testType.equal<IsStringLiteral<never, { selection: 'filter' }>, never>(true)
+	testType.equal<IsStringLiteral<unknown, { selection: 'filter' }>, never>(true)
+	testType.equal<IsStringLiteral<'a' | boolean, { selection: 'filter' }>, 'a'>(true)
+	testType.equal<IsStringLiteral<'abc' | 1>, boolean>(true)
+	testType.equal<IsStringLiteral<'abc' | 1, { distributive: false }>, false>(true)
+	testType.equal<IsStringLiteral<`${number}`, { exact: true }>, false>(true)
+	testType.equal<IsStringLiteral<'abc', IsStringLiteral.$Branch>, $Then>(true)
+	testType.equal<IsStringLiteral<string, IsStringLiteral.$Branch>, $Else>(true)
+})
+
+it('IsNotStringLiteral examples in TSDoc are accurate', () => {
+	testType.equal<IsNotStringLiteral<string>, true>(true)
+	testType.equal<IsNotStringLiteral<'a'>, false>(true)
+	testType.equal<IsNotStringLiteral<`${number}`>, false>(true)
+	testType.equal<IsNotStringLiteral<never>, true>(true)
+	testType.equal<IsNotStringLiteral<unknown>, true>(true)
+	testType.equal<IsNotStringLiteral<'a' | boolean>, boolean>(true)
+	testType.equal<IsNotStringLiteral<string, { selection: 'filter' }>, string>(true)
+	testType.equal<IsNotStringLiteral<'a', { selection: 'filter' }>, never>(true)
+	testType.equal<IsNotStringLiteral<never, { selection: 'filter' }>, never>(true)
+	testType.equal<IsNotStringLiteral<unknown, { selection: 'filter' }>, unknown>(true)
+	testType.equal<IsNotStringLiteral<'a' | boolean, { selection: 'filter' }>, boolean>(true)
+	testType.equal<IsNotStringLiteral<'abc' | 1>, boolean>(true)
+	testType.equal<IsNotStringLiteral<'abc' | 1, { distributive: false }>, true>(true)
+	testType.equal<IsNotStringLiteral<`${number}`, { exact: true }>, true>(true)
+	testType.equal<IsNotStringLiteral<'abc', IsNotStringLiteral.$Branch>, $Else>(true)
+	testType.equal<IsNotStringLiteral<string, IsNotStringLiteral.$Branch>, $Then>(true)
+})
+
+it('IsTemplateLiteral examples in TSDoc are accurate', () => {
+	testType.equal<IsTemplateLiteral<string>, false>(true)
+	testType.equal<IsTemplateLiteral<'foo'>, false>(true)
+	testType.equal<IsTemplateLiteral<`a${number}`>, true>(true)
+	testType.equal<IsTemplateLiteral<`a${number}` | `${bigint}c`>, true>(true)
+	testType.equal<IsTemplateLiteral<never>, false>(true)
+	testType.equal<IsTemplateLiteral<unknown>, false>(true)
+	testType.equal<IsTemplateLiteral<`${number}` | boolean>, boolean>(true)
+	testType.equal<IsTemplateLiteral<`${number}`, { selection: 'filter' }>, `${number}`>(true)
+	testType.equal<IsTemplateLiteral<'a', { selection: 'filter' }>, never>(true)
+	testType.equal<IsTemplateLiteral<`${number}` | 1>, boolean>(true)
+	testType.equal<IsTemplateLiteral<`${number}` | 1, { distributive: false }>, false>(true)
+	testType.equal<IsTemplateLiteral<`${number}`, IsTemplateLiteral.$Branch>, $Then>(true)
+	testType.equal<IsTemplateLiteral<bigint, IsTemplateLiteral.$Branch>, $Else>(true)
+})
+
+it('IsNotTemplateLiteral examples in TSDoc are accurate', () => {
+	testType.equal<IsNotTemplateLiteral<string>, true>(true)
+	testType.equal<IsNotTemplateLiteral<'foo'>, true>(true)
+	testType.equal<IsNotTemplateLiteral<`a${number}`>, false>(true)
+	testType.equal<IsNotTemplateLiteral<never>, true>(true)
+	testType.equal<IsNotTemplateLiteral<unknown>, true>(true)
+	testType.equal<IsNotTemplateLiteral<`${number}` | boolean>, boolean>(true)
+	testType.equal<IsNotTemplateLiteral<`${number}`, { selection: 'filter' }>, never>(true)
+	testType.equal<IsNotTemplateLiteral<'a', { selection: 'filter' }>, 'a'>(true)
+	testType.equal<IsNotTemplateLiteral<`${number}` | 1>, boolean>(true)
+	testType.equal<IsNotTemplateLiteral<`${number}` | 1, { distributive: false }>, true>(true)
+	testType.equal<IsNotTemplateLiteral<`${number}`, IsNotTemplateLiteral.$Branch>, $Else>(true)
+	testType.equal<IsNotTemplateLiteral<bigint, IsNotTemplateLiteral.$Branch>, $Then>(true)
+})
+
+it('StringIncludes and StringSplit examples in TSDoc are accurate', () => {
+	testType.equal<StringIncludes<'abc', 'a'>, true>(true)
+	testType.equal<StringIncludes<'abc', 'd'>, false>(true)
+	testType.equal<StringSplit<'abc', ''>, ['a', 'b', 'c']>(true)
+	testType.equal<StringSplit<'abc', 'a'>, ['', 'bc']>(true)
+	testType.equal<StringSplit<'abc', 'b'>, ['a', 'c']>(true)
+	testType.equal<StringSplit<'abc', 'c'>, ['ab', '']>(true)
+})
+
+it('$ExtractManipulatedString examples on the docs site are accurate', () => {
+	// `Uppercase<'abc'>` resolves to `'ABC'` before the type sees it, so there is
+	// no wrapper left to unwrap. Only an unresolved intrinsic can be seen through.
+	testType.equal<$ExtractManipulatedString<Uppercase<string>>, string>(true)
+	testType.equal<$ExtractManipulatedString<Uppercase<'abc'>>, 'ABC'>(true)
+	testType.equal<$ExtractManipulatedString<'abc'>, 'abc'>(true)
+})
+
+it('StringPlus examples in TSDoc are accurate', () => {
+	testType.equal<StringPlus.Includes<'abc', 'a'>, true>(true)
+	testType.equal<StringPlus.Includes<'abc', 'd'>, false>(true)
+	testType.equal<StringPlus.Split<'abc', ''>, ['a', 'b', 'c']>(true)
+	testType.equal<StringPlus.Split<'abc', 'a'>, ['', 'bc']>(true)
+	testType.equal<StringPlus.Split<'abc', 'b'>, ['a', 'c']>(true)
+	testType.equal<StringPlus.Split<'abc', 'c'>, ['ab', '']>(true)
+})

--- a/packages/type-plus/src/tuple/drop.ts
+++ b/packages/type-plus/src/tuple/drop.ts
@@ -57,7 +57,7 @@ export namespace DropFirst {
  *
  * @example
  * ```ts
- * type R = DropLast<[1, 2, 3]> // [2, 3]
+ * type R = DropLast<[1, 2, 3]> // [1, 2]
  * type R = DropLast<[string]> // []
  * type R = DropLast<[]> // []
  * type R = DropLast<string[]> // string[]

--- a/packages/type-plus/src/tuple/is_not_tuple.ts
+++ b/packages/type-plus/src/tuple/is_not_tuple.ts
@@ -38,7 +38,7 @@ import type { NotAssignable } from '../predicates/not_assignable.js'
  * type R = IsNotTuple<never, { selection: 'filter' }> // never
  * type R = IsNotTuple<unknown, { selection: 'filter' }> // unknown
  * type R = IsNotTuple<[] | boolean, { selection: 'filter' }> // boolean
- * type R = IsNotTuple<[1] | bigint> // bigint
+ * type R = IsNotTuple<[1] | bigint, { selection: 'filter' }> // bigint
  * ```
  *
  * 🔢 *customize*:
@@ -47,7 +47,7 @@ import type { NotAssignable } from '../predicates/not_assignable.js'
  *
  * ```ts
  * type R = IsNotTuple<[] | 1> // boolean
- * type R = IsNotTuple<[] | 1, { distributive: false }> // false
+ * type R = IsNotTuple<[] | 1, { distributive: false }> // true
  * ```
  *
  * 🔢 *customize*

--- a/packages/type-plus/src/tuple/tuple_docs.spec.ts
+++ b/packages/type-plus/src/tuple/tuple_docs.spec.ts
@@ -1,0 +1,96 @@
+/**
+ * Pins the `@example` blocks in the `src/tuple/*.ts` TSDoc comments to the
+ * actual behavior.
+ *
+ * Every assertion here mirrors a line documented in `src/tuple/*.ts`, so a doc
+ * example that drifts from the implementation fails to compile.
+ *
+ * Follows the pattern introduced for the numeric family in #662.
+ */
+import { it } from 'vitest'
+
+import {
+	type $Else,
+	type $Then,
+	type CommonPropKeys,
+	type DropFirst,
+	type DropLast,
+	type DropMatch,
+	type IsNotTuple,
+	type IsTuple,
+	type TuplePlus,
+	testType,
+} from '../index.js'
+
+it('IsTuple examples in TSDoc are accurate', () => {
+	testType.equal<IsTuple<[]>, true>(true)
+	testType.equal<IsTuple<number[]>, false>(true)
+	testType.equal<IsTuple<string>, false>(true)
+	testType.equal<IsTuple<never>, false>(true)
+	testType.equal<IsTuple<unknown>, false>(true)
+	testType.equal<IsTuple<[], { selection: 'filter' }>, []>(true)
+	testType.equal<IsTuple<[1], { selection: 'filter' }>, [1]>(true)
+	testType.equal<IsTuple<never, { selection: 'filter' }>, never>(true)
+	testType.equal<IsTuple<unknown, { selection: 'filter' }>, never>(true)
+	testType.equal<IsTuple<[] | boolean, { selection: 'filter' }>, []>(true)
+	testType.equal<IsTuple<[1] | 1>, boolean>(true)
+	testType.equal<IsTuple<[] | 1, { distributive: false }>, false>(true)
+	testType.equal<IsTuple<[], IsTuple.$Branch>, $Then>(true)
+	testType.equal<IsTuple<string, IsTuple.$Branch>, $Else>(true)
+})
+
+it('IsNotTuple examples in TSDoc are accurate', () => {
+	testType.equal<IsNotTuple<[]>, false>(true)
+	testType.equal<IsNotTuple<[1]>, false>(true)
+	testType.equal<IsNotTuple<number[]>, true>(true)
+	testType.equal<IsNotTuple<string>, true>(true)
+	testType.equal<IsNotTuple<never>, true>(true)
+	testType.equal<IsNotTuple<unknown>, true>(true)
+	testType.equal<IsNotTuple<[], { selection: 'filter' }>, never>(true)
+	testType.equal<IsNotTuple<[1], { selection: 'filter' }>, never>(true)
+	testType.equal<IsNotTuple<never, { selection: 'filter' }>, never>(true)
+	testType.equal<IsNotTuple<unknown, { selection: 'filter' }>, unknown>(true)
+	testType.equal<IsNotTuple<[] | boolean, { selection: 'filter' }>, boolean>(true)
+	testType.equal<IsNotTuple<[1] | bigint, { selection: 'filter' }>, bigint>(true)
+	testType.equal<IsNotTuple<[] | 1>, boolean>(true)
+	testType.equal<IsNotTuple<[] | 1, { distributive: false }>, true>(true)
+	testType.equal<IsNotTuple<bigint, IsNotTuple.$Branch>, $Then>(true)
+	testType.equal<IsNotTuple<[], IsNotTuple.$Branch>, $Else>(true)
+})
+
+it('Drop examples in TSDoc are accurate', () => {
+	testType.equal<DropFirst<[1, 2, 3]>, [2, 3]>(true)
+	testType.equal<DropFirst<[string]>, []>(true)
+	testType.equal<DropFirst<[]>, []>(true)
+	testType.equal<DropFirst<string[]>, string[]>(true)
+	testType.equal<DropLast<[1, 2, 3]>, [1, 2]>(true)
+	testType.equal<DropLast<[string]>, []>(true)
+	testType.equal<DropLast<[]>, []>(true)
+	testType.equal<DropLast<string[]>, string[]>(true)
+	testType.equal<DropMatch<Array<string | undefined>, undefined>, string[]>(true)
+	testType.equal<DropMatch<Array<string>, string>, never[]>(true)
+	testType.equal<DropMatch<Array<1 | 2>, number>, never[]>(true)
+})
+
+it('CommonPropKeys examples in TSDoc are accurate', () => {
+	testType.equal<CommonPropKeys<[{ a: number }, { b: number }]>, never>(true)
+	testType.equal<CommonPropKeys<[{ a: number; c: 1 }, { b: number; c: 2 }]>, 'c'>(true)
+	testType.equal<TuplePlus.CommonPropKeys<[{ a: number }, { b: number }]>, never>(true)
+	testType.equal<TuplePlus.CommonPropKeys<[{ a: number; c: 1 }, { b: number; c: 2 }]>, 'c'>(true)
+})
+
+it('TuplePlus.Filter examples in TSDoc are accurate', () => {
+	testType.equal<TuplePlus.Filter<[1, 2, '3'], number>, [1, 2]>(true)
+	testType.equal<TuplePlus.Filter<[1, 2, '3'], true>, []>(true)
+})
+
+it('TuplePlus.Find examples in TSDoc are accurate', () => {
+	testType.equal<TuplePlus.Find<[true, 1, 'x', 3], string>, 'x'>(true)
+	testType.equal<TuplePlus.Find<[true, 1, 'x', 3], number>, 1>(true)
+	testType.equal<TuplePlus.Find<[string, number, 1], 1>, 1 | undefined>(true)
+	testType.equal<TuplePlus.Find<[true, number | string], string>, string>(true)
+	testType.equal<TuplePlus.Find<[true, number | string], string, { $unionNotMatch: undefined }>, string | undefined>(
+		true,
+	)
+	testType.equal<TuplePlus.Find<[true, 1, 'x'], 2>, never>(true)
+})

--- a/packages/type-plus/src/tuple/tuple_plus.filter.ts
+++ b/packages/type-plus/src/tuple/tuple_plus.filter.ts
@@ -5,8 +5,8 @@
  *
  * @example
  * ```ts
- * type R = Filter<[1, 2, '3'], number> // [1, 2]
- * type R = Filter<[1, 2, '3'], true> // []
+ * type R = TuplePlus.Filter<[1, 2, '3'], number> // [1, 2]
+ * type R = TuplePlus.Filter<[1, 2, '3'], true> // []
  * ```
  */
 export type Filter<T extends readonly unknown[], Criteria = true> = T['length'] extends 0

--- a/packages/type-plus/src/tuple/tuple_plus.find.ts
+++ b/packages/type-plus/src/tuple/tuple_plus.find.ts
@@ -13,8 +13,12 @@ import type { IsTuple } from './is_tuple.js'
  * ```ts
  * type R = TuplePlus.Find<[true, 1, 'x', 3], string> // 'x'
  * type R = TuplePlus.Find<[true, 1, 'x', 3], number> // 1
- * type R = TuplePlus.Find<[string, number, 1], 1> // widen: 1 | undefined
- * type R = TuplePlus.Find<[true, number | string], string> // unionMiss: string | undefined
+ * type R = TuplePlus.Find<[string, number, 1], 1> // 1 | undefined (widen match)
+ * type R = TuplePlus.Find<[true, number | string], string> // string
+ *
+ * // `$unionNotMatch` defaults to `never`, so the non-matching branch drops out.
+ * // Set it to `undefined` for JavaScript-like behavior:
+ * type R = TuplePlus.Find<[true, number | string], string, { $unionNotMatch: undefined }> // string | undefined
  *
  * type R = TuplePlus.Find<[true, 1, 'x'], 2> // never
  * ```

--- a/packages/type-plus/src/union/union.ts
+++ b/packages/type-plus/src/union/union.ts
@@ -5,9 +5,9 @@
  *
  * @example
  * ```ts
- * type R = IsUnion<'a' | 'b'> // 'a' | 'b'
- * type R = IsUnion<boolean> // boolean
- * type R = IsUnion<number> // never
+ * type R = UnionType<'a' | 'b'> // 'a' | 'b'
+ * type R = UnionType<boolean> // boolean
+ * type R = UnionType<number> // never
  * ```
  */
 export type UnionType<T, Then = T, Else = never> = UnionType.Device<T, Then, Else>

--- a/packages/type-plus/src/union/union_docs.spec.ts
+++ b/packages/type-plus/src/union/union_docs.spec.ts
@@ -1,0 +1,24 @@
+/**
+ * Pins the `@example` blocks in the `src/union/*.ts` TSDoc comments to the
+ * actual behavior.
+ *
+ * Every assertion here mirrors a line documented in `src/union/*.ts`, so a doc
+ * example that drifts from the implementation fails to compile.
+ *
+ * Follows the pattern introduced for the numeric family in #662.
+ */
+import { it } from 'vitest'
+
+import { type IsUnion, testType, type UnionType } from '../index.js'
+
+it('UnionType examples in TSDoc are accurate', () => {
+	testType.equal<UnionType<'a' | 'b'>, 'a' | 'b'>(true)
+	testType.equal<UnionType<boolean>, boolean>(true)
+	testType.equal<UnionType<number>, never>(true)
+})
+
+it('IsUnion examples in TSDoc are accurate', () => {
+	testType.equal<IsUnion<'a' | 'b'>, true>(true)
+	testType.equal<IsUnion<boolean>, true>(true)
+	testType.equal<IsUnion<number>, false>(true)
+})


### PR DESCRIPTION
## What

Extends the compiled-example pattern to four more families. Adds:

- `packages/type-plus/src/string/string_docs.spec.ts`
- `packages/type-plus/src/object/object_docs.spec.ts`
- `packages/type-plus/src/tuple/tuple_docs.spec.ts`
- `packages/type-plus/src/union/union_docs.spec.ts`

Each mirrors every `@example` line in its family with a `testType.equal`, so a documented example that drifts from the implementation stops compiling.

## Relationship to #662

#662 is not merged, so this does **not** build on it — the pattern is replicated independently and the two do not overlap. #662 touches `src/numeric/`, `src/number/`, `src/bigint/` and `apps/website/.../number.md`; this touches `src/string/`, `src/object/`, `src/tuple/`, `src/union/` and `apps/website/.../string.md`. They should merge in either order. The `Follows the pattern introduced for the numeric family in #662` header in each new spec is the only reference.

`src/nominal/` was on the suggested list but has **no `@example` blocks at all** — nothing to pin. It is one of the families reported in #669 as a documentation gap.

## Doc errors found: 25

Checked by evaluating every documented example through the compiler and comparing against the stated result. **All 25 are documentation errors. None is an implementation bug**, so no behavior changes here and nothing needed to be pinned-with-a-suspicion.

### Wrong values (6)

| Documented | Actual |
| --- | --- |
| `IsNotString<never> // false` | `true` |
| `IsNotString<unknown> // false` | `true` |
| `IsNotString<string \| 1, { distributive: false }> // false` | `true` |
| `IsNotTuple<[] \| 1, { distributive: false }> // false` | `true` |
| `DropLast<[1, 2, 3]> // [2, 3]` | `[1, 2]` — copied from `DropFirst` |
| `$ExtractManipulatedString<Uppercase<'abc'>> // 'abc'` (docs site) | `'ABC'` |

The first four are the same class of error #662 found in the numeric family: the special types are not strings, so `IsNotString` *accepts* them, and the negation of a `distributive: false` check flips with it. `IsString<never>` is documented correctly as `false` — only the negations were wrong.

`$ExtractManipulatedString<Uppercase<'abc'>>` is worth a note: `Uppercase<'abc'>` resolves to `'ABC'` before the type ever sees it, so there is no wrapper left to unwrap. The type can only see through an *unresolved* intrinsic. The page now says so and shows `$ExtractManipulatedString<Uppercase<string>> // string` alongside.

### Wrong type named (4)

- `IsObject`'s doc block opened with `type R = IsNotObject<object> // true` — the wrong type, and `IsNotObject<object>` is `false` anyway. It should be, and now is, `IsObject<object> // true`.
- `IsTemplateLiteral` and `IsNotTemplateLiteral` each used `$IsString.$Branch` for their `$Else`/`$Then` example.
- `TuplePlus.Filter`'s examples were written as bare `Filter`, which at the top level resolves to the unrelated array `Filter`.
- `UnionType`'s examples were written as `IsUnion`, which made the block read as a contradiction of the `IsUnion` block ten lines below it (`IsUnion<'a' | 'b'>` documented as both `'a' | 'b'` and `true`).

### Missing the option being demonstrated (3)

`IsObject<{} | bigint> // {}`, `IsNotObject<{} | bigint> // bigint` and `IsNotTuple<[1] | bigint> // bigint` all sat inside their `selection: 'filter'` example block without carrying `{ selection: 'filter' }`. As written each resolves to `boolean`.

### Non-existent branch selector names (10)

`$IsString.$Branch`, `$IsNotString.$Branch`, `$IsStringLiteral.$Branch`, `$IsNotStringLiteral.$Branch`, `$IsTemplateLiteral.$Branch`, `$IsNotTemplateLiteral.$Branch` (six files, `$`-prefixed names that do not exist) and the retired `$SelectionBranch` in `IsObject` / `IsNotObject`. Same stale-name class #662 fixed in the `number` and `bigint` examples.

### Ambiguous default (1)

`TuplePlus.Find<[true, number | string], string>` was documented as `string | undefined`. `$unionNotMatch` defaults to `never`, so the non-matching branch drops out and the answer is `string`. The example now shows the default and the `{ $unionNotMatch: undefined }` override that produces the documented value.

## Why the count matters

Five families checked (one of which had nothing to check), 25 errors. #662 found 2 in one family. The remaining families — `array`, `null`, `void`, `testing`, `function`, `promise`, `predicates`, `equal`, `math`, `boolean` — have not been checked, and there is no reason to think they are cleaner. Every one of these errors was invisible to CI before, and every one is exactly the kind of thing an agent reading the `.d.ts` would act on as fact.

## Scope and conflicts

Deliberately avoids `src/array/`, `src/null/`, `src/void/`, `src/testing/`, `src/numeric/`, `packages/type-plus/readme.md` and `apps/website/.../tuple.md`, `array.md`, `testing.md`, `number.md` — all under active edit by #658–#664. The one website file touched is `string.md`, which no open PR is editing.

## Verification

`pnpm -w turbo build lint test` and `pnpm --filter type-plus test:type` (5.4 / 5.5 / 5.6 / 6.0 / 7) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BUybspzGX8c3w7u3egBTQp
