### PR TITLE
docs(type-plus): document the object family's 36 undocumented exports

### DIFF
--- a/.changeset/wild-apes-shave.md
+++ b/.changeset/wild-apes-shave.md
@@ -1,0 +1,20 @@
+---
+'type-plus': patch
+---
+
+Document the 36 undocumented exports in `src/object/`.
+
+Every `@example` is pinned by a compiled assertion in
+`src/object/object_docs.spec.ts`, so an example that drifts from the
+implementation fails to build.
+
+Four of the newly documented types do not do what their names say. The
+documentation records the behavior rather than changing it:
+
+- `KnownKeys<T>` resolves to `never` for every `T` on every supported
+  TypeScript version.
+- `KeysOfOptional<T>` returns `keyof T` when every property is required, and
+  `never` as soon as one is optional.
+- `RecursiveRequired<T>` does not descend into optional properties.
+- `hasKey()` and `hasProperty()` test truthiness rather than key presence, and
+  `getField()` replaces any falsy value with the default.

--- a/packages/type-plus/src/object/ANotB.ts
+++ b/packages/type-plus/src/object/ANotB.ts
@@ -3,10 +3,46 @@ import type { AnyRecord } from './any_record.js'
 import type { IsDisjoint } from './IsDisjoint.js'
 import type { KeysWithDiffType } from './KeysWithDiffType.js'
 
+/**
+ * ⚗️ *transform*
+ *
+ * The part of `A` that `B` does not already satisfy:
+ * the properties of `A` that `B` lacks, plus the properties both declare with
+ * incompatible types.
+ *
+ * The two ends short-circuit: identical records produce `never`
+ * (nothing is missing), and records sharing no keys produce `A` unchanged
+ * (nothing is satisfied).
+ *
+ * @example
+ * ```ts
+ * type A = { a: number; b: string }
+ * type B = { a: number; b: number; c: boolean }
+ *
+ * type R = ANotB<A, B> // { b: string }
+ *
+ * type R = ANotB<A, A> // never
+ * type R = ANotB<{ a: 1 }, { b: 2 }> // { a: 1 }
+ * ```
+ */
 export type ANotB<A extends AnyRecord, B extends AnyRecord> = IsEqual<A, B> extends true
 	? never
 	: IsDisjoint<A, B> extends true
 		? A
 		: { [k in Exclude<keyof A, keyof B> | KeysWithDiffType<A, B>]: A[k] }
 
+/**
+ * ⚗️ *transform*
+ *
+ * `ANotB` with the arguments swapped: the part of `B` that `A` does not
+ * already satisfy.
+ *
+ * @example
+ * ```ts
+ * type A = { a: number; b: string }
+ * type B = { a: number; b: number; c: boolean }
+ *
+ * type R = BNotA<A, B> // { b: number; c: boolean }
+ * ```
+ */
 export type BNotA<A extends AnyRecord, B extends AnyRecord> = ANotB<B, A>

--- a/packages/type-plus/src/object/IsRecord.ts
+++ b/packages/type-plus/src/object/IsRecord.ts
@@ -1,1 +1,20 @@
+/**
+ * 🎭 *predicate*
+ *
+ * Validate if `T` is a record, i.e. assignable to `Record<any, any>` and not an
+ * array.
+ *
+ * Note that this is a plain `extends` check rather than one of the `$Options`
+ * predicates: it takes no options, and it does not special-case `any`,
+ * `never` or `unknown`.
+ *
+ * @example
+ * ```ts
+ * type R = IsRecord<{ a: 1 }> // true
+ * type R = IsRecord<Record<string, number>> // true
+ *
+ * type R = IsRecord<number[]> // false
+ * type R = IsRecord<string> // false
+ * ```
+ */
 export type IsRecord<T> = T extends any[] ? false : T extends Record<any, any> ? true : false

--- a/packages/type-plus/src/object/KeyofOptional.ts
+++ b/packages/type-plus/src/object/KeyofOptional.ts
@@ -3,4 +3,23 @@
  */
 export type KeyofOptional<T> = T extends Record<infer U, any> ? U : never
 
+/**
+ * ⚗️ *transform*
+ *
+ * Infers the key type of `T` as a record, i.e. the `K` in `Record<K, any>`.
+ *
+ * ⚠️ The name promises more than the implementation delivers. This does *not*
+ * select the optional keys of `T`: for a record whose properties are all
+ * required it returns the whole key union, and the moment any property is
+ * optional the inference fails and it returns `never`. Use `OptionalKeys<T>`
+ * for the optional keys, and `keyof T` for the key union.
+ *
+ * @example
+ * ```ts
+ * type R = KeysOfOptional<{ a: 1; b: 2 }> // 'a' | 'b'
+ * type R = KeysOfOptional<Record<'x' | 'y', number>> // 'x' | 'y'
+ *
+ * type R = KeysOfOptional<{ a?: 1; b: 2 }> // never
+ * ```
+ */
 export type KeysOfOptional<T> = T extends Record<infer U, any> ? U : never

--- a/packages/type-plus/src/object/KeysWithDiffType.ts
+++ b/packages/type-plus/src/object/KeysWithDiffType.ts
@@ -2,6 +2,32 @@ import type { AnyRecord } from './any_record.js'
 import type { IsDisjoint } from './IsDisjoint.js'
 import type { ValueOf } from './ValueOf.js'
 
+/**
+ * ⚗️ *transform*
+ *
+ * The keys `A` and `B` share whose property types disagree,
+ * i.e. the keys `k` of both where `A[k]` is not assignable to `B[k]`.
+ *
+ * The comparison runs one way. A key is reported when `A[k]` does not extend
+ * `B[k]`, so a widening (`1` against `number`) is not a difference while the
+ * narrowing (`number` against `1`) is.
+ *
+ * Records sharing no keys short-circuit to `never`.
+ *
+ * @example
+ * ```ts
+ * type A = { a: number; b: string }
+ * type B = { a: number; b: number; c: boolean }
+ *
+ * type R = KeysWithDiffType<A, B> // 'b'
+ *
+ * type R = KeysWithDiffType<{ a: 1 }, { a: number }> // never
+ * type R = KeysWithDiffType<{ a: number }, { a: 1 }> // 'a'
+ *
+ * type R = KeysWithDiffType<{ a: 1 }, { a: 1 }> // never
+ * type R = KeysWithDiffType<{ a: 1 }, { b: 2 }> // never
+ * ```
+ */
 export type KeysWithDiffType<A extends AnyRecord, B extends AnyRecord> = IsDisjoint<A, B> extends true
 	? never
 	: ValueOf<{

--- a/packages/type-plus/src/object/KnownKeys.ts
+++ b/packages/type-plus/src/object/KnownKeys.ts
@@ -5,6 +5,29 @@
 import type { PrimitiveTypes } from '../primitive.js'
 
 // https://github.com/microsoft/TypeScript/issues/25987#issuecomment-441224690
+/**
+ * ⚗️ *transform*
+ *
+ * Intended to select the keys of `T` that are declared explicitly, dropping the
+ * ones contributed by a `string` or `number` index signature.
+ *
+ * ⚠️ It no longer does that. Under every TypeScript version this package
+ * supports the body resolves to `never` for every `T`, including records with
+ * no index signature at all. The `{} extends U` guard the trick relies on has
+ * not held since the compiler changed how homomorphic mapped types are
+ * compared. The examples below pin what it actually produces, not what the
+ * name suggests.
+ *
+ * Its own spec passes only vacuously: `never` is assignable to every type, so
+ * an `assertType<'a' | 'b'>` check cannot detect the collapse.
+ *
+ * @example
+ * ```ts
+ * type R = KnownKeys<{ a: 1; b: 2 }> // never
+ * type R = KnownKeys<{ a?: boolean; [k: string]: any }> // never
+ * type R = KnownKeys<string> // never
+ * ```
+ */
 export type KnownKeys<T> = T extends PrimitiveTypes
 	? never
 	: {

--- a/packages/type-plus/src/object/Partial.ts
+++ b/packages/type-plus/src/object/Partial.ts
@@ -13,7 +13,20 @@ export type Partial<T> = { [P in keyof T]?: T[P] | undefined }
 export type PartialPick<T, U extends UnionKeys<T>> = T extends T ? Omit<T, U> & Partial<Pick<T, U>> : never
 
 /**
- * @deprecated replaced by `PartialOmit`
+ * ⚗️ *transform*
+ *
+ * Keeps the selected properties `U` as declared and applies `Partial<>` to the
+ * rest -- the same body as `PartialOmit`.
+ *
+ * @deprecated replaced by `PartialOmit`, which says what it does: the selected
+ * keys are the ones kept, not the ones excluded. This alias is kept for the v7
+ * migration and will be dropped.
+ *
+ * @example
+ * ```ts
+ * type R = PartialExcept<{ a: 1; b: 2; c: 3 }, 'a'>
+ * // { a: 1; b?: 2 | undefined; c?: 3 | undefined }
+ * ```
  */
 export type PartialExcept<T, U extends UnionKeys<T>> = T extends T ? Pick<T, U> & Partial<Omit<T, U>> : never
 

--- a/packages/type-plus/src/object/RecursiveRequired.ts
+++ b/packages/type-plus/src/object/RecursiveRequired.ts
@@ -1,5 +1,29 @@
 import type { AnyRecord } from './any_record.js'
 
+/**
+ * ⚗️ *transform*
+ *
+ * Makes every property of `T` required, descending into nested records and
+ * into array element types.
+ *
+ * ⚠️ The descent stops at optional properties. `T[P]` on an optional property
+ * includes `undefined`, and `undefined` is not a record, so the recursive
+ * branch is never taken: the property is made required and its own optional
+ * properties are left alone. Only already-required nested records are
+ * processed recursively. Since making optional properties required is the
+ * point of the type, this limit bites at exactly the case you would reach for
+ * it.
+ *
+ * @example
+ * ```ts
+ * // required nesting recurses
+ * type R = RecursiveRequired<{ a: { b?: number } }> // { a: { b: number } }
+ * type R = RecursiveRequired<{ a: Array<{ b?: number }> }> // { a: Array<{ b: number }> }
+ *
+ * // optional nesting does not
+ * type R = RecursiveRequired<{ a?: { b?: number } }> // { a: { b?: number } }
+ * ```
+ */
 export type RecursiveRequired<T> = {
 	[P in keyof T]-?: T[P] extends (infer U)[]
 		? RecursiveRequired<U>[]

--- a/packages/type-plus/src/object/Required.ts
+++ b/packages/type-plus/src/object/Required.ts
@@ -1,7 +1,42 @@
 // Thanks [jack-williams](https://github.com/jack-williams) for the [solution](https://github.com/Microsoft/TypeScript/issues/29269#issuecomment-451602962)
 
+/**
+ * ⚗️ *transform*
+ *
+ * Makes every property of `T` required.
+ *
+ * Unlike the built-in `Required<T>`, this also strips `undefined` out of the
+ * property type, so a required-but-nullable property becomes non-nullable too.
+ *
+ * @example
+ * ```ts
+ * type R = Required<{ a?: number; b: string | undefined }> // { a: number; b: string }
+ * ```
+ */
 export type Required<T> = { [P in keyof T]-?: Exclude<T[P], undefined> }
 
+/**
+ * ⚗️ *transform*
+ *
+ * Applies `Required<>` to the selected properties `U`, leaving the rest of `T`
+ * as declared.
+ *
+ * @example
+ * ```ts
+ * type R = RequiredPick<{ a?: 1; b?: 2 }, 'a'> // { a: 1; b?: 2 }
+ * ```
+ */
 export type RequiredPick<T, U extends keyof T> = Required<Pick<T, U>> & Pick<T, Exclude<keyof T, U>>
 
+/**
+ * ⚗️ *transform*
+ *
+ * Applies `Required<>` to every property except the selected `U`, which is
+ * left as declared. The complement of `RequiredPick`.
+ *
+ * @example
+ * ```ts
+ * type R = RequiredExcept<{ a?: 1; b?: 2 }, 'a'> // { b: 2; a?: 1 }
+ * ```
+ */
 export type RequiredExcept<T, U extends keyof T> = Required<Pick<T, Exclude<keyof T, U>>> & Pick<T, U>

--- a/packages/type-plus/src/object/RequiredKeys.ts
+++ b/packages/type-plus/src/object/RequiredKeys.ts
@@ -1,6 +1,19 @@
 import type { KeyTypes } from './KeyTypes.js'
 import type { OptionalKeys } from './optional_key.js'
 
+/**
+ * ⚗️ *transform*
+ *
+ * The keys of `T` that are required, i.e. `keyof T` minus `OptionalKeys<T>`.
+ *
+ * Distributes over a union, so each member contributes its own required keys.
+ *
+ * @example
+ * ```ts
+ * type R = RequiredKeys<{ a: 1; b?: 2 }> // 'a'
+ * type R = RequiredKeys<{ a: 1 } | { b: 2; c?: 3 }> // 'a' | 'b'
+ * ```
+ */
 export type RequiredKeys<T extends Record<KeyTypes, any>> = T extends unknown ? RequiredKeys._<T> : never
 
 export namespace RequiredKeys {

--- a/packages/type-plus/src/object/SpreadRecord.ts
+++ b/packages/type-plus/src/object/SpreadRecord.ts
@@ -1,4 +1,22 @@
 import type { Omit } from '../object/index.js'
 
+/**
+ * ⚗️ *transform*
+ *
+ * The type of `{ ...a, ...b }`: the properties of `A` that `B` does not
+ * redeclare, intersected with all of `B`. On a collision `B` wins.
+ *
+ * The result is an intersection rather than a flattened object literal.
+ *
+ * For a version that also reconciles optionality and `Record` shapes, see
+ * `ObjectPlus.Merge`.
+ *
+ * @example
+ * ```ts
+ * type R = SpreadRecord<{ a: number; b: string }, { b: boolean; c: number }>
+ * // { a: number } & { b: boolean; c: number }
+ * // resolved: { a: number; b: boolean; c: number }
+ * ```
+ */
 export type SpreadRecord<A extends Record<any, any>, B extends Record<any, any>> = Omit<A, Extract<keyof A, keyof B>> &
 	B

--- a/packages/type-plus/src/object/ValueOf.ts
+++ b/packages/type-plus/src/object/ValueOf.ts
@@ -1,1 +1,14 @@
+/**
+ * ⚗️ *transform*
+ *
+ * The union of the property types of `T`.
+ * The value-level counterpart of `keyof T`.
+ *
+ * @example
+ * ```ts
+ * type R = ValueOf<{ a: 1; b: 2 }> // 1 | 2
+ * type R = ValueOf<{ a: number; b: string }> // number | string
+ * type R = ValueOf<Record<string, boolean>> // boolean
+ * ```
+ */
 export type ValueOf<T> = T[keyof T]

--- a/packages/type-plus/src/object/any_record.ts
+++ b/packages/type-plus/src/object/any_record.ts
@@ -1,3 +1,19 @@
 import type { KeyTypes } from './KeyTypes.js'
 
+/**
+ * 🧰 *type util*
+ *
+ * A constraint matching any record: every key type JavaScript allows
+ * (`string`, `number`, `symbol`) mapped to `any`.
+ *
+ * Use it where a type parameter must be "some object with properties" rather
+ * than `object`, which also admits functions and arrays.
+ *
+ * @example
+ * ```ts
+ * type R = AnyRecord // { [x: string]: any; [x: number]: any; [x: symbol]: any }
+ *
+ * function f<T extends AnyRecord>(subject: T) { return subject }
+ * ```
+ */
 export type AnyRecord = Record<KeyTypes, any>

--- a/packages/type-plus/src/object/everyKey.ts
+++ b/packages/type-plus/src/object/everyKey.ts
@@ -1,5 +1,22 @@
 import type { KeyTypes } from './KeyTypes.js'
 
+/**
+ * `Array.prototype.every` over the *keys* of `subject`, in `Object.keys()`
+ * order. `true` when the predicate holds for every key, and `true` for an
+ * empty record.
+ *
+ * Only own enumerable string keys are visited; symbol keys and inherited
+ * properties are skipped.
+ *
+ * @example
+ * ```ts
+ * const r = everyKey({ a: 1, b: 2 }, (k) => typeof k === 'string')
+ * // r === true
+ *
+ * const r = everyKey({ a: 1, b: 2 }, (k) => k === 'a')
+ * // r === false
+ * ```
+ */
 export function everyKey<S extends Record<KeyTypes, any>, T = any>(
 	subject: S,
 	predicate: (this: T, key: keyof S, index: number, array: string[]) => unknown,

--- a/packages/type-plus/src/object/filterKey.ts
+++ b/packages/type-plus/src/object/filterKey.ts
@@ -1,5 +1,18 @@
 import type { KeyTypes } from './KeyTypes.js'
 
+/**
+ * `Array.prototype.filter` over the *keys* of `subject`. Returns the keys the
+ * predicate accepts, as an array, in `Object.keys()` order.
+ *
+ * Note the return type is `Array<keyof S>` -- the keys, not a filtered record.
+ *
+ * @example
+ * ```ts
+ * const r = filterKey({ a: 1, b: 2 }, (k) => k === 'a')
+ * // r === ['a']
+ * // typeof r === Array<'a' | 'b'>
+ * ```
+ */
 export function filterKey<S extends Record<KeyTypes, any>, T = any>(
 	subject: S,
 	predicate: (this: T, key: keyof S, index: number, obj: Array<keyof S>, subject: S) => boolean,

--- a/packages/type-plus/src/object/findKey.ts
+++ b/packages/type-plus/src/object/findKey.ts
@@ -1,5 +1,19 @@
 import type { KeyTypes } from './KeyTypes.js'
 
+/**
+ * `Array.prototype.find` over the *keys* of `subject`. Returns the first key
+ * the predicate accepts in `Object.keys()` order, or `undefined` when none do.
+ *
+ * @example
+ * ```ts
+ * const r = findKey({ a: 1, b: 2 }, (k) => k === 'b')
+ * // r === 'b'
+ * // typeof r === 'a' | 'b' | undefined
+ *
+ * const r = findKey({ a: 1 }, () => false)
+ * // r === undefined
+ * ```
+ */
 export function findKey<S extends Record<KeyTypes, any>, T = any>(
 	subject: S,
 	predicate: (this: T, key: keyof S, index: number, obj: Array<keyof S>, subject: S) => boolean,

--- a/packages/type-plus/src/object/forEachKey.ts
+++ b/packages/type-plus/src/object/forEachKey.ts
@@ -1,5 +1,19 @@
 import type { KeyTypes } from './KeyTypes.js'
 
+/**
+ * `Array.prototype.forEach` over the *keys* of `subject`, in `Object.keys()`
+ * order. Returns nothing.
+ *
+ * Unlike the other key iterators here the callback does *not* receive
+ * `subject`, so close over it to reach the values.
+ *
+ * @example
+ * ```ts
+ * const seen: string[] = []
+ * forEachKey({ a: 1, b: 2 }, (k) => { seen.push(String(k)) })
+ * // seen === ['a', 'b']
+ * ```
+ */
 export function forEachKey<S extends Record<KeyTypes, any>, T = any>(
 	subject: S,
 	predicate: (this: T, key: keyof S, index: number, obj: Array<keyof S>) => void,

--- a/packages/type-plus/src/object/getField.ts
+++ b/packages/type-plus/src/object/getField.ts
@@ -1,5 +1,26 @@
 import type { UnionKeys } from '../union_keys.js'
 
+/**
+ * Reads `subject[key]`, tolerating a `null` or `undefined` subject.
+ *
+ * With a `defaultValue`, that value is returned whenever the lookup produces
+ * anything falsy. ⚠️ Two consequences worth knowing: the check is `||`, not a
+ * nullish check, so `0`, `''` and `false` stored on the object are replaced by
+ * the default; and the overload types the result as the default's own type
+ * (`DV`), not `TX[K] | DV`, so a literal default narrows the result to that
+ * literal.
+ *
+ * @example
+ * ```ts
+ * const o = { a: 1 } as { a: number } | undefined
+ *
+ * const r = getField(o, 'a') // 1, typed number
+ * const r = getField(undefined as typeof o, 'a') // undefined
+ *
+ * const r = getField(o, 'a', 5) // 1, but typed 5
+ * const r = getField({ a: 0 } as { a: number }, 'a', 5) // 5 -- 0 is falsy
+ * ```
+ */
 export function getField<T, TX extends Exclude<T, undefined | null>, K extends UnionKeys<TX>>(subject: T, key: K): TX[K]
 export function getField<
 	T,

--- a/packages/type-plus/src/object/hasKey.ts
+++ b/packages/type-plus/src/object/hasKey.ts
@@ -1,7 +1,40 @@
 import type { AnyRecord } from './any_record.js'
 
+/**
+ * 🎭 *predicate*
+ *
+ * Validate if `K` is a key of `T`, returning `Then` (default `true`) or `Else`
+ * (default `false`).
+ *
+ * A plain `extends` check with no `$Options` support: it takes the branches as
+ * ordinary type parameters and does not special-case `any`, `never` or
+ * `unknown`.
+ *
+ * @example
+ * ```ts
+ * type R = HasKey<{ a: 1 }, 'a'> // true
+ * type R = HasKey<{ a: 1 }, 'b'> // false
+ *
+ * type R = HasKey<{ a: 1 }, 'b', 'yes', 'no'> // 'no'
+ * ```
+ */
 export type HasKey<T, K, Then = true, Else = false> = K extends keyof T ? Then : Else
 
+/**
+ * Checks the given keys on `subject`, typed as `HasKey<T, K>`.
+ *
+ * ⚠️ The runtime and the type disagree. The type is decided by whether `K` is
+ * a key of `T`, so it is `true` for any declared key; the implementation tests
+ * `subject[key]` for *truthiness*, so a declared key holding `0`, `''`,
+ * `null` or `false` returns `false` at runtime while the type still says
+ * `true`. It is a truthiness check, not `in`.
+ *
+ * @example
+ * ```ts
+ * const r = hasKey({ a: 1 }, 'a') // true, typed true
+ * const r = hasKey({ a: 0 }, 'a') // false at runtime, still typed true
+ * ```
+ */
 export function hasKey<T extends AnyRecord, K extends string>(subject: T, ...keys: K[]): HasKey<T, K> {
 	return !keys.some((key) => !subject[key]) as unknown as HasKey<T, K>
 }

--- a/packages/type-plus/src/object/hasProperty.ts
+++ b/packages/type-plus/src/object/hasProperty.ts
@@ -1,5 +1,30 @@
 import type { UnionKeys } from '../union_keys.js'
 
+/**
+ * A type guard narrowing `value` to `T & Record<P, T[P]>`.
+ *
+ * ⚠️ Two limits worth knowing before reaching for it to discriminate a union.
+ *
+ * The runtime check is `!!value[prop]`, i.e. truthiness rather than `in`, so a
+ * property that is present but holds `0`, `''`, `null`, `undefined` or `false`
+ * fails the guard.
+ *
+ * And on a union, `T[P]` is `unknown` rather than the member's own property
+ * type, so the narrowed value is
+ * `{ a: number } | ({ b: string } & Record<'a', unknown>)` and reading the
+ * property gives `unknown`. Narrowing a union by a discriminant is better
+ * served by a `'a' in v` check.
+ *
+ * @example
+ * ```ts
+ * const v = { a: 1 } as { a: number } | { b: string }
+ * if (hasProperty(v, 'a')) {
+ *   v.a // unknown, not number
+ * }
+ *
+ * hasProperty({ a: 0 }, 'a') // false -- 0 is falsy
+ * ```
+ */
 export function hasProperty<T, P extends UnionKeys<T>>(value: T, prop: P): value is T & Record<P, T[P]> {
 	return !!value[prop]
 }

--- a/packages/type-plus/src/object/left_join.ts
+++ b/packages/type-plus/src/object/left_join.ts
@@ -3,6 +3,27 @@ import type { AnyRecord } from './any_record.js'
 import type { IsDisjoint } from './IsDisjoint.js'
 import type { Properties } from './properties.js'
 
+/**
+ * ⚗️ *transform*
+ *
+ * Joins `B` onto `A`: the properties of `A` that `B` does not redeclare, plus
+ * all of `B`. On a collision `B` wins.
+ *
+ * Unlike `SpreadRecord`, the overlapping case is flattened through
+ * `Properties`, so the result is a single object type rather than an
+ * intersection. The two short-circuits are not flattened: identical records
+ * return `A` as-is, and records sharing no keys return the intersection
+ * `A & B`.
+ *
+ * @example
+ * ```ts
+ * type R = LeftJoin<{ a: number; b: string }, { b: number; c: boolean }>
+ * // { a: number; b: number; c: boolean }
+ *
+ * type R = LeftJoin<{ a: 1 }, { a: 1 }> // { a: 1 }
+ * type R = LeftJoin<{ a: 1 }, { b: 2 }> // { a: 1 } & { b: 2 }
+ * ```
+ */
 export type LeftJoin<A extends AnyRecord, B extends AnyRecord> = IsEqual<A, B> extends true
 	? A
 	: IsDisjoint<A, B> extends true

--- a/packages/type-plus/src/object/mapKey.ts
+++ b/packages/type-plus/src/object/mapKey.ts
@@ -1,5 +1,18 @@
 import type { KeyTypes } from './KeyTypes.js'
 
+/**
+ * `Array.prototype.map` over the *keys* of `subject`. Returns an array of the
+ * callback results in `Object.keys()` order -- an array, not a record.
+ *
+ * @example
+ * ```ts
+ * const r = mapKey({ a: 1, b: 2 }, (k, i) => `${String(k)}${i}`)
+ * // r === ['a0', 'b1']
+ *
+ * const r = mapKey({ a: 1, b: 2 }, (k, _i, _a, s) => s[k])
+ * // r === [1, 2]
+ * ```
+ */
 export function mapKey<R, S extends Record<KeyTypes, any>, T = any>(
 	subject: S,
 	predicate: (this: T, key: keyof S, index: number, obj: Array<keyof S>, subject: S) => R,

--- a/packages/type-plus/src/object/object_docs.spec.ts
+++ b/packages/type-plus/src/object/object_docs.spec.ts
@@ -7,9 +7,52 @@
  *
  * Follows the pattern introduced for the numeric family in #662.
  */
-import { it } from 'vitest'
+import { expect, it } from 'vitest'
 
-import { type $Else, type $Then, type IsNotObject, type IsObject, type Properties, testType } from '../index.js'
+import {
+	type $Else,
+	type $Then,
+	type ANotB,
+	type AnyRecord,
+	type BNotA,
+	type Except,
+	everyKey,
+	filterKey,
+	findKey,
+	forEachKey,
+	getField,
+	type HasKey,
+	hasKey,
+	hasProperty,
+	type IsNotObject,
+	type IsObject,
+	type IsRecord,
+	type KeysOfOptional,
+	type KeysWithDiffType,
+	type KnownKeys,
+	type LeftJoin,
+	mapKey,
+	type ObjectPlus,
+	omit,
+	type PartialExcept,
+	type Properties,
+	pick,
+	type RecursiveRequired,
+	type ReplaceProperty,
+	type Required,
+	type RequiredExcept,
+	type RequiredKeys,
+	type RequiredPick,
+	record,
+	reduceByKey,
+	replaceProperty,
+	type Split,
+	type SpreadRecord,
+	someKey,
+	testType,
+	typeOverrideIncompatible,
+	type ValueOf,
+} from '../index.js'
 
 it('IsObject examples in TSDoc are accurate', () => {
 	testType.equal<IsObject<object>, true>(true)
@@ -61,4 +104,220 @@ it('Properties examples in TSDoc are accurate', () => {
 	type T = { a: number; b?: string }
 	testType.equal<Properties<T>, { a: number; b?: string }>(true)
 	testType.equal<Properties<{ a: 1 } & { b: 2 }>, { a: 1; b: 2 }>(true)
+})
+
+it('ANotB and BNotA examples in TSDoc are accurate', () => {
+	type A = { a: number; b: string }
+	type B = { a: number; b: number; c: boolean }
+	testType.equal<ANotB<A, B>, { b: string }>(true)
+	testType.equal<ANotB<A, A>, never>(true)
+	testType.equal<ANotB<{ a: 1 }, { b: 2 }>, { a: 1 }>(true)
+	testType.equal<BNotA<A, B>, { b: number; c: boolean }>(true)
+})
+
+it('AnyRecord examples in TSDoc are accurate', () => {
+	testType.equal<AnyRecord, { [x: string]: any; [x: number]: any; [x: symbol]: any }>(true)
+})
+
+it('IsRecord examples in TSDoc are accurate', () => {
+	testType.equal<IsRecord<{ a: 1 }>, true>(true)
+	testType.equal<IsRecord<Record<string, number>>, true>(true)
+	testType.equal<IsRecord<number[]>, false>(true)
+	testType.equal<IsRecord<string>, false>(true)
+})
+
+it('ValueOf examples in TSDoc are accurate', () => {
+	testType.equal<ValueOf<{ a: 1; b: 2 }>, 1 | 2>(true)
+	testType.equal<ValueOf<{ a: number; b: string }>, number | string>(true)
+	testType.equal<ValueOf<Record<string, boolean>>, boolean>(true)
+})
+
+it('KeysOfOptional examples in TSDoc are accurate', () => {
+	testType.equal<KeysOfOptional<{ a: 1; b: 2 }>, 'a' | 'b'>(true)
+	testType.equal<KeysOfOptional<Record<'x' | 'y', number>>, 'x' | 'y'>(true)
+	// the name says otherwise: one optional property collapses the inference
+	testType.equal<KeysOfOptional<{ a?: 1; b: 2 }>, never>(true)
+})
+
+it('KeysWithDiffType examples in TSDoc are accurate', () => {
+	type A = { a: number; b: string }
+	type B = { a: number; b: number; c: boolean }
+	testType.equal<KeysWithDiffType<A, B>, 'b'>(true)
+	// the comparison runs one way only
+	testType.equal<KeysWithDiffType<{ a: 1 }, { a: number }>, never>(true)
+	testType.equal<KeysWithDiffType<{ a: number }, { a: 1 }>, 'a'>(true)
+	testType.equal<KeysWithDiffType<{ a: 1 }, { a: 1 }>, never>(true)
+	testType.equal<KeysWithDiffType<{ a: 1 }, { b: 2 }>, never>(true)
+})
+
+it('KnownKeys examples in TSDoc are accurate', () => {
+	// `never` for every input -- the type no longer does what its name says.
+	// Pinned to the actual behavior; see the TSDoc note on `KnownKeys`.
+	testType.equal<KnownKeys<{ a: 1; b: 2 }>, never>(true)
+	testType.equal<KnownKeys<{ a?: boolean; [k: string]: any }>, never>(true)
+	testType.equal<KnownKeys<string>, never>(true)
+})
+
+it('RecursiveRequired examples in TSDoc are accurate', () => {
+	testType.equal<RecursiveRequired<{ a: { b?: number } }>, { a: { b: number } }>(true)
+	testType.equal<RecursiveRequired<{ a: Array<{ b?: number }> }>, { a: Array<{ b: number }> }>(true)
+	// the descent stops at an optional property; see the TSDoc note
+	testType.equal<RecursiveRequired<{ a?: { b?: number } }>, { a: { b?: number } }>(true)
+})
+
+it('Required, RequiredPick and RequiredExcept examples in TSDoc are accurate', () => {
+	testType.equal<Required<{ a?: number; b: string | undefined }>, { a: number; b: string }>(true)
+	testType.equal<RequiredPick<{ a?: 1; b?: 2 }, 'a'>, { a: 1; b?: 2 }>(true)
+	testType.equal<RequiredExcept<{ a?: 1; b?: 2 }, 'a'>, { b: 2; a?: 1 }>(true)
+})
+
+it('RequiredKeys examples in TSDoc are accurate', () => {
+	testType.equal<RequiredKeys<{ a: 1; b?: 2 }>, 'a'>(true)
+	testType.equal<RequiredKeys<{ a: 1 } | { b: 2; c?: 3 }>, 'a' | 'b'>(true)
+})
+
+it('SpreadRecord examples in TSDoc are accurate', () => {
+	testType.equal<
+		SpreadRecord<{ a: number; b: string }, { b: boolean; c: number }>,
+		{ a: number; b: boolean; c: number }
+	>(true)
+})
+
+it('LeftJoin examples in TSDoc are accurate', () => {
+	testType.equal<LeftJoin<{ a: number; b: string }, { b: number; c: boolean }>, { a: number; b: number; c: boolean }>(
+		true,
+	)
+	testType.equal<LeftJoin<{ a: 1 }, { a: 1 }>, { a: 1 }>(true)
+	testType.equal<LeftJoin<{ a: 1 }, { b: 2 }>, { a: 1 } & { b: 2 }>(true)
+})
+
+it('ReplaceProperty examples in TSDoc are accurate', () => {
+	testType.equal<ReplaceProperty<{ a: number; b: string }, 'a', boolean>, { b: string; a: boolean }>(true)
+})
+
+it('HasKey examples in TSDoc are accurate', () => {
+	testType.equal<HasKey<{ a: 1 }, 'a'>, true>(true)
+	testType.equal<HasKey<{ a: 1 }, 'b'>, false>(true)
+	testType.equal<HasKey<{ a: 1 }, 'b', 'yes', 'no'>, 'no'>(true)
+})
+
+it('Split examples in TSDoc are accurate', () => {
+	testType.equal<Split<{ a: number; b: string }, { a: undefined }>, { a: number }>(true)
+	testType.equal<Split<{ a?: number; b: string }, { a: 1 }>, { a: number }>(true)
+})
+
+it('Except examples in TSDoc are accurate', () => {
+	testType.equal<Except<{ a: 1; b: 2; c: 3 }, 'b'>, { a: 1; c: 3 }>(true)
+})
+
+it('PartialExcept examples in TSDoc are accurate', () => {
+	testType.equal<PartialExcept<{ a: 1; b: 2; c: 3 }, 'a'>, { a: 1; b?: 2 | undefined; c?: 3 | undefined }>(true)
+})
+
+it('ObjectPlus.Merge example in TSDoc is accurate', () => {
+	testType.equal<ObjectPlus.Merge<{ a: number; b: string }, { b: boolean }>, { a: number; b: boolean }>(true)
+})
+
+it('omit examples in TSDoc are accurate', () => {
+	const r = omit({ a: 1, b: 'x', c: true }, 'b')
+	expect(r).toEqual({ a: 1, c: true })
+	testType.equal<typeof r, { a: number; c: boolean }>(true)
+
+	expect(omit({ a: 1, b: 2, c: 3 }, 'a', 'b')).toEqual({ c: 3 })
+
+	// the prototype claim in the TSDoc
+	expect(Object.getPrototypeOf(omit(record<'a' | 'b', number>({ a: 1, b: 2 }), 'a'))).toBe(null)
+	expect(Object.getPrototypeOf(omit({ a: 1, b: 2 }, 'a'))).toBe(Object.prototype)
+})
+
+it('pick examples in TSDoc are accurate', () => {
+	const r = pick({ a: 1, b: 'x', c: true }, 'a', 'c')
+	expect(r).toEqual({ a: 1, c: true })
+	testType.equal<typeof r, { a: number; c: boolean }>(true)
+
+	expect(Object.getPrototypeOf(pick(record<'a' | 'b', number>({ a: 1, b: 2 }), 'a'))).toBe(null)
+	expect(Object.getPrototypeOf(pick({ a: 1, b: 2 }, 'a'))).toBe(Object.prototype)
+})
+
+it('getField examples in TSDoc are accurate', () => {
+	const o = { a: 1 } as { a: number } | undefined
+
+	const r = getField(o, 'a')
+	expect(r).toBe(1)
+	testType.equal<typeof r, number>(true)
+
+	expect(getField(undefined as typeof o, 'a')).toBe(undefined)
+
+	// the default's own literal type wins, and the check is truthiness
+	const d = getField(o, 'a', 5)
+	expect(d).toBe(1)
+	testType.equal<typeof d, 5>(true)
+	expect(getField({ a: 0 } as { a: number }, 'a', 5)).toBe(5)
+})
+
+it('hasKey examples in TSDoc are accurate', () => {
+	const yes = hasKey({ a: 1 }, 'a')
+	expect(yes).toBe(true)
+	testType.equal<typeof yes, true>(true)
+
+	// the documented runtime/type disagreement: truthiness, not `in`
+	const falsy = hasKey({ a: 0 }, 'a')
+	expect(falsy).toBe(false)
+	testType.equal<typeof falsy, true>(true)
+})
+
+it('hasProperty examples in TSDoc are accurate', () => {
+	const v = { a: 1 } as { a: number } | { b: string }
+	if (hasProperty(v, 'a')) {
+		// `T[P]` on a union is `unknown`, so the guard does not recover the
+		// member's own property type; see the TSDoc note on `hasProperty`.
+		testType.equal<typeof v.a, unknown>(true)
+	} else {
+		expect.unreachable()
+	}
+
+	expect(hasProperty({ a: 0 }, 'a')).toBe(false)
+})
+
+it('replaceProperty examples in TSDoc are accurate', () => {
+	const r = replaceProperty({ a: 1, b: 'x' }, 'a', 'z')
+	expect(r).toEqual({ a: 'z', b: 'x' })
+	testType.equal<typeof r, { b: string; a: string }>(true)
+})
+
+it('key iteration examples in TSDoc are accurate', () => {
+	expect(everyKey({ a: 1, b: 2 }, (k) => typeof k === 'string')).toBe(true)
+	expect(everyKey({ a: 1, b: 2 }, (k) => k === 'a')).toBe(false)
+
+	expect(someKey({ a: 1, b: 2 }, (k) => k === 'b')).toBe(true)
+	expect(someKey({ a: 1, b: 2 }, (k, _i, _a, s) => s[k] > 5)).toBe(false)
+
+	const filtered = filterKey({ a: 1, b: 2 }, (k) => k === 'a')
+	expect(filtered).toEqual(['a'])
+	testType.equal<typeof filtered, Array<'a' | 'b'>>(true)
+
+	const found = findKey({ a: 1, b: 2 }, (k) => k === 'b')
+	expect(found).toBe('b')
+	testType.equal<typeof found, 'a' | 'b' | undefined>(true)
+	expect(findKey({ a: 1 }, () => false)).toBe(undefined)
+
+	const seen: string[] = []
+	forEachKey({ a: 1, b: 2 }, (k) => {
+		seen.push(String(k))
+	})
+	expect(seen).toEqual(['a', 'b'])
+
+	expect(mapKey({ a: 1, b: 2 }, (k, i) => `${String(k)}${i}`)).toEqual(['a0', 'b1'])
+	expect(mapKey({ a: 1, b: 2 }, (k, _i, _a, s) => s[k])).toEqual([1, 2])
+
+	expect(reduceByKey({ a: 1, b: 2 }, (acc, k) => acc + String(k), '')).toBe('ab')
+	expect(reduceByKey({ a: 1, b: 2 }, (acc, k, _i, _a, s) => acc + s[k], 0)).toBe(3)
+})
+
+it('typeOverrideIncompatible example in TSDoc is accurate', () => {
+	const toTarget = typeOverrideIncompatible<{ a: number; b: string }>()
+
+	const r = toTarget({ a: 1, b: 2 }, { b: 'x' })
+	expect(r).toEqual({ a: 1, b: 'x' })
+	testType.equal<typeof r, { a: number; b: string }>(true)
 })

--- a/packages/type-plus/src/object/object_plus.ts
+++ b/packages/type-plus/src/object/object_plus.ts
@@ -1,1 +1,24 @@
+/**
+ * 🧰 *namespace*
+ *
+ * The object types that need a namespace to avoid clashing with the built-in
+ * or `type-plus` types of the same name.
+ *
+ * Currently that is `ObjectPlus.Merge<A, B>`, the type-level `{ ...a, ...b }`.
+ * Unlike `SpreadRecord`, it reconciles optional properties and `Record` shapes
+ * instead of intersecting blindly.
+ *
+ * @example
+ * ```ts
+ * type R = ObjectPlus.Merge<{ a: number; b: string }, { b: boolean }>
+ * // { a: number; b: boolean }
+ * ```
+ *
+ * Note: the generator behind `llms.txt` reports this namespace as
+ * undocumented no matter what is written here. `export * as ObjectPlus`
+ * aliases a *module* symbol, and TypeScript does not expose a module's doc
+ * comment through `getDocumentationComment`. The same applies to every other
+ * `*Plus` namespace.
+ */
+
 export * from './merge.js'

--- a/packages/type-plus/src/object/omit.ts
+++ b/packages/type-plus/src/object/omit.ts
@@ -14,10 +14,43 @@ import { reduceByKey } from './reduceKey.js'
 export type Omit<T, K extends UnionKeys<T>> = T extends unknown ? Pick<T, Exclude<keyof T, K>> : never
 
 /**
- * @deprecated replaced by `Omit`
+ * ⚗️ *transform*
+ *
+ * @deprecated replaced by `Omit`, which is the same transform with a wider key
+ * constraint (`UnionKeys<T>` rather than `keyof T`, so it also works on
+ * unions). This alias is kept for the v7 migration and will be dropped; new
+ * code should use `Omit`.
+ *
+ * @example
+ * ```ts
+ * type R = Except<{ a: 1; b: 2; c: 3 }, 'b'> // { a: 1; c: 3 }
+ * ```
  */
 export type Except<T, K extends keyof T> = Omit<T, K>
 
+/**
+ * Returns a copy of `subject` without the named properties, typed
+ * `Omit<T, Props>`.
+ *
+ * `subject` is not mutated. Up to twelve keys have a dedicated overload; past
+ * that a rest overload takes the union. Only own enumerable string keys are
+ * copied, so symbol keys and inherited properties are dropped along with the
+ * omitted ones.
+ *
+ * The prototype is preserved in the one case that matters: a null-prototype
+ * subject (from `record()`) yields a null-prototype result, anything else
+ * yields a plain object.
+ *
+ * @example
+ * ```ts
+ * const r = omit({ a: 1, b: 'x', c: true }, 'b')
+ * // r === { a: 1, c: true }
+ * // typeof r === { a: number; c: boolean }
+ *
+ * const r = omit({ a: 1, b: 2, c: 3 }, 'a', 'b')
+ * // r === { c: 3 }
+ * ```
+ */
 export function omit<T extends AnyRecord, P1 extends UnionKeys<T>>(subject: T, prop1: P1): Omit<T, P1>
 export function omit<T extends AnyRecord, P1 extends UnionKeys<T>, P2 extends UnionKeys<T>>(
 	subject: T,

--- a/packages/type-plus/src/object/pick.ts
+++ b/packages/type-plus/src/object/pick.ts
@@ -3,6 +3,25 @@ import type { AnyRecord } from './any_record.js'
 import { record } from './record.js'
 import { reduceByKey } from './reduceKey.js'
 
+/**
+ * Returns a copy of `subject` containing only the named properties, typed
+ * `Pick<T, Props>`. The complement of `omit()`.
+ *
+ * `subject` is not mutated. Up to twelve keys have a dedicated overload; past
+ * that a rest overload takes the union. A key naming a property that is
+ * absent at runtime simply contributes nothing to the result.
+ *
+ * The prototype is preserved in the one case that matters: a null-prototype
+ * subject (from `record()`) yields a null-prototype result, anything else
+ * yields a plain object.
+ *
+ * @example
+ * ```ts
+ * const r = pick({ a: 1, b: 'x', c: true }, 'a', 'c')
+ * // r === { a: 1, c: true }
+ * // typeof r === { a: number; c: boolean }
+ * ```
+ */
 export function pick<T extends AnyRecord, P1 extends UnionKeys<T>>(subject: T, prop1: P1): Pick<T, P1>
 export function pick<T extends AnyRecord, P1 extends UnionKeys<T>, P2 extends UnionKeys<T>>(
 	subject: T,

--- a/packages/type-plus/src/object/reduceKey.ts
+++ b/packages/type-plus/src/object/reduceKey.ts
@@ -1,5 +1,25 @@
 import type { KeyTypes } from './KeyTypes.js'
 
+/**
+ * `Array.prototype.reduce` over the *keys* of `subject`, in
+ * `Object.keys()` order.
+ *
+ * The callback receives the accumulator, the key, the index, the whole key
+ * array and `subject` itself, so the value is reachable as `subject[key]`
+ * without closing over it.
+ *
+ * Only own enumerable string keys are visited; symbol keys and inherited
+ * properties are skipped.
+ *
+ * @example
+ * ```ts
+ * const r = reduceByKey({ a: 1, b: 2 }, (acc, k) => acc + String(k), '')
+ * // r === 'ab'
+ *
+ * const sum = reduceByKey({ a: 1, b: 2 }, (acc, k, _i, _a, s) => acc + s[k], 0)
+ * // sum === 3
+ * ```
+ */
 export function reduceByKey<S extends Record<KeyTypes, any>, T>(
 	subject: S,
 	callbackfn: (previousValue: T, key: keyof S, currentIndex: number, array: string[], subject: S) => T,
@@ -9,6 +29,15 @@ export function reduceByKey<S extends Record<KeyTypes, any>, T>(
 }
 
 /**
- * @deprecated renamed to reduceByKey
+ * The former name of `reduceByKey`, re-exported unchanged.
+ *
+ * @deprecated renamed to `reduceByKey`. Kept for the v7 migration; it will be
+ * dropped.
+ *
+ * @example
+ * ```ts
+ * const r = reduceKey({ a: 1, b: 2 }, (acc, k) => acc + String(k), '')
+ * // r === 'ab'
+ * ```
  */
 export const reduceKey = reduceByKey

--- a/packages/type-plus/src/object/replaceProperty.ts
+++ b/packages/type-plus/src/object/replaceProperty.ts
@@ -1,7 +1,36 @@
 import type { AnyRecord } from './any_record.js'
 
+/**
+ * ⚗️ *transform*
+ *
+ * Replaces the type of property `K` on `T` with `V`.
+ *
+ * The result is an intersection, and the replaced key moves to the end of the
+ * resolved shape.
+ *
+ * @example
+ * ```ts
+ * type R = ReplaceProperty<{ a: number; b: string }, 'a', boolean>
+ * // Omit<{ a: number; b: string }, 'a'> & { a: boolean }
+ * // resolved: { b: string; a: boolean }
+ * ```
+ */
 export type ReplaceProperty<T extends AnyRecord, K extends keyof T, V> = Omit<T, K> & { [P in K]: V }
 
+/**
+ * Returns a copy of `subject` with property `key` set to `value`, typed as
+ * `ReplaceProperty<T, K, V>`.
+ *
+ * `subject` is not mutated; the copy is a shallow spread, so nested values are
+ * shared.
+ *
+ * @example
+ * ```ts
+ * const r = replaceProperty({ a: 1, b: 'x' }, 'a', 'z')
+ * // r === { a: 'z', b: 'x' }
+ * // typeof r === Omit<{ a: number; b: string }, 'a'> & { a: string }
+ * ```
+ */
 export function replaceProperty<T extends AnyRecord, K extends keyof T, V>(
 	subject: T,
 	key: K,

--- a/packages/type-plus/src/object/someKey.ts
+++ b/packages/type-plus/src/object/someKey.ts
@@ -1,5 +1,22 @@
 import type { KeyTypes } from './KeyTypes.js'
 
+/**
+ * `Array.prototype.some` over the *keys* of `subject`, in `Object.keys()`
+ * order. `true` when the predicate holds for at least one key, and `false` for
+ * an empty record.
+ *
+ * The predicate also receives `subject` as its fourth argument, so the value
+ * is reachable as `subject[key]`.
+ *
+ * @example
+ * ```ts
+ * const r = someKey({ a: 1, b: 2 }, (k) => k === 'b')
+ * // r === true
+ *
+ * const r = someKey({ a: 1, b: 2 }, (k, _i, _a, s) => s[k] > 5)
+ * // r === false
+ * ```
+ */
 export function someKey<S extends Record<KeyTypes, any>, T = any>(
 	subject: S,
 	predicate: (this: T, key: keyof S, index: number, array: string[], subject: S) => unknown,

--- a/packages/type-plus/src/object/split.ts
+++ b/packages/type-plus/src/object/split.ts
@@ -5,6 +5,23 @@ import type { Partial } from './Partial.js'
 import { reduceByKey } from './reduceKey.js'
 
 type Splitter<T extends AnyRecord> = Partial<{ [k in keyof T]: T[k] | undefined }>
+/**
+ * ⚗️ *transform*
+ *
+ * The type of one slice produced by `split()`: the keys of the splitter `S`,
+ * all required.
+ *
+ * Where the splitter names a key with `undefined` the property is taken from
+ * `T` as declared. Where it supplies a fallback value the property becomes
+ * `NonNullable<T[k]> | Exclude<S[k], undefined>`, since the fallback stands in
+ * whenever `T` has nothing for that key.
+ *
+ * @example
+ * ```ts
+ * type R = Split<{ a: number; b: string }, { a: undefined }> // { a: number }
+ * type R = Split<{ a?: number; b: string }, { a: 1 }> // { a: number }
+ * ```
+ */
 export type Split<T extends AnyRecord, S extends AnyRecord> = {
 	[k in keyof S]-?: S[k] extends undefined ? T[k] : NonNullable<T[k]> | Exclude<S[k], undefined>
 }

--- a/packages/type-plus/src/object/typeOverrideIncompatible.ts
+++ b/packages/type-plus/src/object/typeOverrideIncompatible.ts
@@ -1,5 +1,28 @@
 import type { ANotB, AnyRecord } from './index.js'
 
+/**
+ * Curried helper for reshaping a value into `A` while making the compiler
+ * demand exactly the parts that do not already fit.
+ *
+ * `typeOverrideIncompatible<A>()` returns a function taking the `source` and an
+ * `override` constrained to `ANotB<A, B>` -- the properties of `A` that
+ * `source` is missing or declares with an incompatible type. Adding the right
+ * property to `source` removes it from what the override has to supply, so the
+ * compiler tracks the remaining work rather than accepting a blanket cast.
+ *
+ * At runtime it is `{ ...source, ...override }`, so the override wins on a
+ * collision, and the result is typed `A`.
+ *
+ * @example
+ * ```ts
+ * const toTarget = typeOverrideIncompatible<{ a: number; b: string }>()
+ *
+ * const r = toTarget({ a: 1, b: 2 }, { b: 'x' })
+ * // r === { a: 1, b: 'x' }, typed { a: number; b: string }
+ * // `b` must be supplied: number is not assignable to string.
+ * // `a` must not: it already fits.
+ * ```
+ */
 export function typeOverrideIncompatible<A extends AnyRecord>() {
 	return <B extends AnyRecord>(source: B, override: ANotB<A, B>): A => ({
 		...source,


### PR DESCRIPTION
Slice 1 of #669. Documents **36 of the 88** undocumented exports — every one in `src/object/`, the largest single gap.

Running the `--undocumented` report from #670's generator against this branch: **88 → 53** of 272 exported symbols with no TSDoc.

## Method

Every `@example` is pinned by a compiled assertion in `src/object/object_docs.spec.ts` (29 tests, up from 3), following the pattern from #662 and #671. The examples were written **from what the compiler reports**, not from what the names promise: each type was resolved with the actual checker first, and the resolved string is what the example states. Value-level functions get runtime pins (`expect`) alongside the type pins.

That order is what turned up the discrepancies below. None of them were guessable from the names.

## Doc/implementation discrepancies found

These are documented as they **behave**, with a ⚠️ note in the TSDoc and a pinned test. No behavior was changed — that is a separate, deliberate call.

| Symbol | What the name says | What it does |
| --- | --- | --- |
| `KnownKeys<T>` | the explicitly-declared keys of `T`, dropping index-signature keys | **`never` for every `T`**, on ts-5.4, 5.5, 5.6, 6.0 and 7 alike. The `{} extends U` trick it rests on no longer holds. Its own spec passes only vacuously — `never` is assignable to everything, so `assertType<'a' \| 'b'>` cannot detect the collapse. |
| `KeysOfOptional<T>` | the optional keys of `T` | `keyof T` when every property is required; **`never` as soon as one is optional**. It is `T extends Record<infer U, any> ? U : never` — a record key inference, not an optionality filter. |
| `RecursiveRequired<T>` | makes every property required, recursively | **Does not descend into optional properties.** `T[P]` on an optional property includes `undefined`, which is not a record, so the recursive branch is never taken. Only already-required nested records recurse — i.e. it fails at exactly the case you reach for it. |
| `hasKey()` | has the key | Tests `subject[key]` for **truthiness**, not `in`. `hasKey({ a: 0 }, 'a')` is `false` at runtime while the return type is still `true`. The type and the runtime disagree. |
| `hasProperty()` | type guard for property presence | Also truthiness rather than `in`; and on a union `T[P]` widens to `unknown`, so `v.a` after the guard is `unknown`, not `number`. It does not usefully discriminate a union. |
| `getField()` | read a field with a default | The default is applied on any **falsy** value (`\|\|`, not `??`), and the overload types the result as the default's own type `DV`, so `getField(o, 'a', 5)` is typed `5` rather than `number \| 5`. |

`KeysWithDiffType` is not wrong, but its one-way comparison is worth stating: `KeysWithDiffType<{ a: 1 }, { a: number }>` is `never` while the reverse is `'a'`. Pinned both ways.

## Deprecated exports

Three of the 36 are on their way out. Each keeps a short description (so it is no longer "undocumented"), an example, and a `@deprecated` line naming the replacement, rather than a full write-up:

- `Except` → `Omit`
- `PartialExcept` → `PartialOmit`
- `reduceKey` → `reduceByKey`

None of them are in #658's removal set, so they still ship.

## One symbol the generator will still count

`ObjectPlus` is documented on `src/object/object_plus.ts`, but the `--undocumented` report still lists it, so the count lands at 53 rather than 52. `export * as ObjectPlus from './object/object_plus.js'` aliases a **module** symbol, and TypeScript does not expose a module's doc comment through `getDocumentationComment` — I tried a plain leading comment, `@module` and `@packageDocumentation`. This is structural and affects every `*Plus` namespace (`ArrayPlus`, `MathPlus`, `NumberPlus`, `NumericPlus`, `StringPlus`, `TuplePlus` — 6 more of the 88). Worth a look on the #670 generator rather than a workaround here; a note in the source records why.

## Collision notes

- No `llms.txt` to regenerate: the generator lands with #670, which is still open. Whichever of the two merges second will need the count refreshed.
- #658 touches `src/object/*.spec.ts` but none of the `.ts` sources here, and its spec edits do not overlap `object_docs.spec.ts`.

## Verification

- `pnpm -w turbo build lint test` — green (269 test files passed, 2 skipped).
- `pnpm --filter type-plus test:type` — green on TypeScript 5.4, 5.5, 5.6, 6.0 and 7.
- `biome check` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xn6KQWjN8xYGnwnQiCfRFD
