### PR TITLE
docs(type-plus): document the math family's 9 undocumented exports

### DIFF
--- a/.changeset/olive-jars-repeat.md
+++ b/.changeset/olive-jars-repeat.md
@@ -1,0 +1,20 @@
+---
+'type-plus': patch
+---
+
+Document the 9 undocumented exports in `src/math/`.
+
+Every `@example` is pinned by a compiled assertion in
+`src/math/math_docs.spec.ts`, so an example that drifts from the
+implementation fails to build.
+
+The edges these types were missing documentation for are the ones a caller
+cannot guess:
+
+- `GreaterThan` and `Max` accept `bigint` in their constraint but resolve to
+  `Fail` for every `bigint` argument.
+- Arithmetic on fractional literals whose result is a whole number resolves to
+  an error string rather than a number.
+- `Add`, `Subtract` and `Multiply` are exact decimal, so `Add<0.1, 0.2>` is
+  `0.3` where the runtime gives `0.30000000000000004`.
+- Nothing guards overflow past `Number.MAX_SAFE_INTEGER`.

--- a/packages/type-plus/src/math/abs.ts
+++ b/packages/type-plus/src/math/abs.ts
@@ -2,14 +2,25 @@ import type { $Else, $Then } from '../$type/branch/$selection.js'
 import type { IsBigint } from '../bigint/is_bigint.js'
 import type { IsNumber } from '../number/is_number.js'
 
-/*
- * Returns the absolute value of a number or bigint `N`.
+/**
+ * ⚗️ *transform*
+ *
+ * The absolute value of the numeric literal `N`.
+ *
+ * Works on `number` and `bigint` literals, integer or fractional. Only
+ * *literals*: the widened `number` and `bigint` types carry no value to take
+ * the absolute of, so they resolve to `Fail` (`never` by default).
  *
  * @example
  * ```ts
- * Abs<-5> // 5
- * Abs<5> // 5
- * Abs<-1n> // 1n  // Where `1n` is a bigint
+ * type R = Abs<-5> // 5
+ * type R = Abs<5> // 5
+ * type R = Abs<0> // 0
+ * type R = Abs<-1.5> // 1.5
+ * type R = Abs<-1n> // 1n
+ *
+ * type R = Abs<number> // never
+ * type R = Abs<number, 'nope'> // 'nope'
  * ```
  */
 export type Abs<N extends number | bigint, Fail = never> = IsNumber<N, IsNumber.$Branch> extends infer R

--- a/packages/type-plus/src/math/add.ts
+++ b/packages/type-plus/src/math/add.ts
@@ -1,5 +1,51 @@
 import type { NumericStruct } from './numeric_struct.js'
 
+/**
+ * ⚗️ *transform*
+ *
+ * `A + B` at the type level, on `number` and `bigint` literals.
+ *
+ * Mixing the two is allowed and the result is a `bigint`.
+ *
+ * Fractional arithmetic is exact decimal, not binary floating point, so it
+ * disagrees with the runtime: `Add<0.1, 0.2>` is `0.3` where `0.1 + 0.2`
+ * evaluates to `0.30000000000000004`.
+ *
+ * ⚠️ Two limits this family shares, both easy to trip:
+ *
+ * - **Only literals.** The widened `number` and `bigint` types carry no value,
+ *   so they resolve to `Fail` (`never` by default).
+ * - **A whole-number result from fractional inputs does not resolve to a
+ *   number.** It resolves to the error *string*
+ *   `"The value '4.0' cannot be represented as bigint or number"`, because the
+ *   intermediate is formatted as `4.0` and TypeScript will not parse that back
+ *   to a numeric literal. Fractional results are fine.
+ *
+ * There is no overflow guard: a result past `Number.MAX_SAFE_INTEGER` is
+ * produced anyway, and is no longer exact.
+ *
+ * @example
+ * ```ts
+ * type R = Add<1, 2> // 3
+ * type R = Add<-1, 2> // 1
+ * type R = Add<-1, -2> // -3
+ * type R = Add<0, 0> // 0
+ * type R = Add<1n, 2n> // 3n
+ * type R = Add<1n, 2> // 3n -- bigint wins
+ *
+ * type R = Add<0.1, 0.2> // 0.3 -- exact, unlike the runtime
+ * type R = Add<1, 0.5> // 1.5
+ *
+ * // past Number.MAX_SAFE_INTEGER, produced but no longer exact
+ * type R = Add<9007199254740991, 1> // 9007199254740992
+ *
+ * type R = Add<number, 1> // never
+ * type R = Add<number, 1, 'nope'> // 'nope'
+ *
+ * // a whole-number result from fractional inputs
+ * type R = Add<1.5, 2.5> // "The value '4.0' cannot be represented as bigint or number"
+ * ```
+ */
 export type Add<A extends number | bigint, B extends number | bigint, Fail = never> = [
 	NumericStruct.FromNumeric<A, Fail>,
 	NumericStruct.FromNumeric<B, Fail>,
@@ -11,4 +57,20 @@ export type Add<A extends number | bigint, B extends number | bigint, Fail = nev
 		: Fail
 	: never
 
+/**
+ * ⚗️ *transform*
+ *
+ * `N + 1`. `Add<N, 1>` with no `Fail` parameter, so a non-literal `N` gives
+ * `never`.
+ *
+ * @example
+ * ```ts
+ * type R = Increment<1> // 2
+ * type R = Increment<-1> // 0
+ * type R = Increment<1.5> // 2.5
+ * type R = Increment<1n> // 2n
+ *
+ * type R = Increment<number> // never
+ * ```
+ */
 export type Increment<N extends number | bigint> = Add<N, 1>

--- a/packages/type-plus/src/math/greater_than.ts
+++ b/packages/type-plus/src/math/greater_than.ts
@@ -1,6 +1,39 @@
 import type { IsPositive } from '../numeric/is_positive.js'
 import type { Subtract } from './subtract.js'
 
+/**
+ * 🎭 *predicate*
+ *
+ * `A > B` at the type level, on `number` literals.
+ *
+ * It is implemented as `Subtract<A, B>` followed by a sign check, which is
+ * where its two limits come from.
+ *
+ * ⚠️ **`bigint` does not work**, despite the constraint accepting it. The
+ * intermediate difference is a `bigint` literal, which does not satisfy the
+ * `extends number` guard, so every `bigint` comparison resolves to `Fail` --
+ * `never` by default. `GreaterThan<2n, 1n>` is `never`, not `true`.
+ *
+ * ⚠️ Fractional comparisons work only when the difference is itself
+ * fractional. When the difference is a whole number, `Subtract` yields an
+ * error string rather than a numeric literal and the result is `Fail`:
+ * `GreaterThan<1.5, 2.5>` is `never`.
+ *
+ * A non-literal `number` is `Fail` for the usual reason -- no value to compare.
+ *
+ * @example
+ * ```ts
+ * type R = GreaterThan<2, 1> // true
+ * type R = GreaterThan<1, 1> // false
+ * type R = GreaterThan<1, 2> // false
+ * type R = GreaterThan<-1, -2> // true
+ * type R = GreaterThan<1.5, 1.4> // true
+ *
+ * type R = GreaterThan<number, 1> // never
+ * type R = GreaterThan<2n, 1n> // never -- bigint is not supported
+ * type R = GreaterThan<1.5, 2.5> // never -- the difference is a whole number
+ * ```
+ */
 export type GreaterThan<A extends number | bigint, B extends number | bigint, Fail = never> = Subtract<
 	A,
 	B,

--- a/packages/type-plus/src/math/math_docs.spec.ts
+++ b/packages/type-plus/src/math/math_docs.spec.ts
@@ -1,0 +1,137 @@
+/**
+ * Pins the `@example` blocks in the `src/math/*.ts` TSDoc comments to the
+ * actual behavior.
+ *
+ * Every assertion here mirrors a line documented in `src/math/*.ts`, so a doc
+ * example that drifts from the implementation fails to compile.
+ *
+ * Follows the pattern introduced for the numeric family in #662.
+ */
+import { it } from 'vitest'
+
+import {
+	type Abs,
+	type Add,
+	type Decrement,
+	type GreaterThan,
+	type Increment,
+	type MathPlus,
+	type Max,
+	type Multiply,
+	type Subtract,
+	testType,
+} from '../index.js'
+
+/**
+ * The error string every operation in this family yields when fractional
+ * inputs produce a whole-number result. Spelled once so the tests below read
+ * as the limit they are pinning rather than as a string comparison.
+ */
+type WholeFromFractional<N extends string> = `The value '${N}' cannot be represented as bigint or number`
+
+it('Abs examples in TSDoc are accurate', () => {
+	testType.equal<Abs<-5>, 5>(true)
+	testType.equal<Abs<5>, 5>(true)
+	testType.equal<Abs<0>, 0>(true)
+	testType.equal<Abs<-1.5>, 1.5>(true)
+	testType.equal<Abs<-1n>, 1n>(true)
+
+	testType.equal<Abs<number>, never>(true)
+	testType.equal<Abs<number, 'nope'>, 'nope'>(true)
+})
+
+it('Add examples in TSDoc are accurate', () => {
+	testType.equal<Add<1, 2>, 3>(true)
+	testType.equal<Add<-1, 2>, 1>(true)
+	testType.equal<Add<-1, -2>, -3>(true)
+	testType.equal<Add<0, 0>, 0>(true)
+	testType.equal<Add<1n, 2n>, 3n>(true)
+	testType.equal<Add<1n, 2>, 3n>(true)
+
+	// exact decimal, unlike `0.1 + 0.2 === 0.30000000000000004` at runtime
+	testType.equal<Add<0.1, 0.2>, 0.3>(true)
+	testType.equal<Add<1, 0.5>, 1.5>(true)
+
+	// no overflow guard
+	testType.equal<Add<9007199254740991, 1>, 9007199254740992>(true)
+
+	testType.equal<Add<number, 1>, never>(true)
+	testType.equal<Add<number, 1, 'nope'>, 'nope'>(true)
+
+	// a whole-number result from fractional inputs; see the TSDoc note
+	testType.equal<Add<1.5, 2.5>, WholeFromFractional<'4.0'>>(true)
+})
+
+it('Increment examples in TSDoc are accurate', () => {
+	testType.equal<Increment<1>, 2>(true)
+	testType.equal<Increment<-1>, 0>(true)
+	testType.equal<Increment<1.5>, 2.5>(true)
+	testType.equal<Increment<1n>, 2n>(true)
+
+	testType.equal<Increment<number>, never>(true)
+})
+
+it('Subtract examples in TSDoc are accurate', () => {
+	testType.equal<Subtract<3, 1>, 2>(true)
+	testType.equal<Subtract<1, 3>, -2>(true)
+	testType.equal<Subtract<3n, 1n>, 2n>(true)
+	testType.equal<Subtract<5, 1.5>, 3.5>(true)
+	testType.equal<Subtract<1.5, 1.4>, 0.1>(true)
+
+	testType.equal<Subtract<number, 1>, never>(true)
+
+	testType.equal<Subtract<1.5, 0.5>, WholeFromFractional<'1.0'>>(true)
+})
+
+it('Decrement examples in TSDoc are accurate', () => {
+	testType.equal<Decrement<1>, 0>(true)
+	testType.equal<Decrement<0>, -1>(true)
+	testType.equal<Decrement<1.5>, 0.5>(true)
+	testType.equal<Decrement<1n>, 0n>(true)
+
+	testType.equal<Decrement<number>, never>(true)
+})
+
+it('Multiply examples in TSDoc are accurate', () => {
+	testType.equal<Multiply<3, 4>, 12>(true)
+	testType.equal<Multiply<-3, 4>, -12>(true)
+	testType.equal<Multiply<3, 0>, 0>(true)
+	testType.equal<Multiply<3n, 4n>, 12n>(true)
+
+	testType.equal<Multiply<number, 2>, never>(true)
+
+	// no overflow guard
+	testType.equal<Multiply<9007199254740991, 2>, 18014398509481982>(true)
+
+	testType.equal<Multiply<0.5, 4>, WholeFromFractional<'2.0'>>(true)
+})
+
+it('GreaterThan examples in TSDoc are accurate', () => {
+	testType.equal<GreaterThan<2, 1>, true>(true)
+	testType.equal<GreaterThan<1, 1>, false>(true)
+	testType.equal<GreaterThan<1, 2>, false>(true)
+	testType.equal<GreaterThan<-1, -2>, true>(true)
+	testType.equal<GreaterThan<1.5, 1.4>, true>(true)
+
+	testType.equal<GreaterThan<number, 1>, never>(true)
+	// bigint is accepted by the constraint but not supported by the body
+	testType.equal<GreaterThan<2n, 1n>, never>(true)
+	// the difference is a whole number, so `Subtract` yields an error string
+	testType.equal<GreaterThan<1.5, 2.5>, never>(true)
+})
+
+it('Max examples in TSDoc are accurate', () => {
+	testType.equal<Max<1, 2>, 2>(true)
+	testType.equal<Max<1, 1>, 1>(true)
+	testType.equal<Max<-1, -2>, -1>(true)
+
+	testType.equal<Max<number, 1>, never>(true)
+	testType.equal<Max<2n, 1n>, never>(true)
+	testType.equal<Max<1.5, 2.5>, never>(true)
+})
+
+it('MathPlus examples in TSDoc are accurate', () => {
+	testType.equal<MathPlus.ToNegative<5>, -5>(true)
+	testType.equal<MathPlus.ToNegative<-5>, -5>(true)
+	testType.equal<MathPlus.Add<1, 2>, 3>(true)
+})

--- a/packages/type-plus/src/math/math_plus.ts
+++ b/packages/type-plus/src/math/math_plus.ts
@@ -1,3 +1,26 @@
+/**
+ * 🧰 *namespace*
+ *
+ * The math types that need a namespace to avoid clashing with a type of the
+ * same name elsewhere on the surface, plus the everyday arithmetic re-exported
+ * for convenience.
+ *
+ * `MathPlus.ToNegative<N>` is the one that only lives here.
+ *
+ * @example
+ * ```ts
+ * type R = MathPlus.ToNegative<5> // -5
+ * type R = MathPlus.ToNegative<-5> // -5
+ * type R = MathPlus.Add<1, 2> // 3
+ * ```
+ *
+ * Note: the generator behind `llms.txt` reports this namespace as
+ * undocumented no matter what is written here. `export * as MathPlus` aliases
+ * a *module* symbol, and TypeScript does not expose a module's doc comment
+ * through `getDocumentationComment`. The same applies to every other `*Plus`
+ * namespace.
+ */
+
 export type { Add, Increment } from './add.js'
 export type { ToNegative } from './math_plus.to_negative.js'
 export type { Multiply } from './multiply.js'

--- a/packages/type-plus/src/math/max.ts
+++ b/packages/type-plus/src/math/max.ts
@@ -1,6 +1,28 @@
 import type { IsNever } from '../never/is_never.js'
 import type { GreaterThan } from './greater_than.js'
 
+/**
+ * ⚗️ *transform*
+ *
+ * The larger of `A` and `B`, on `number` literals. Ties return `B`, which is
+ * the same value.
+ *
+ * Built on `GreaterThan`, so it inherits every one of its limits: `bigint` is
+ * not supported, a fractional pair whose difference is a whole number is not
+ * supported, and a non-literal operand is not supported. Each of those
+ * resolves to `Fail` (`never` by default).
+ *
+ * @example
+ * ```ts
+ * type R = Max<1, 2> // 2
+ * type R = Max<1, 1> // 1
+ * type R = Max<-1, -2> // -1
+ *
+ * type R = Max<number, 1> // never
+ * type R = Max<2n, 1n> // never -- bigint is not supported
+ * type R = Max<1.5, 2.5> // never -- the difference is a whole number
+ * ```
+ */
 export type Max<A extends number | bigint, B extends number | bigint, Fail = never> = GreaterThan<
 	A,
 	B

--- a/packages/type-plus/src/math/multiply.ts
+++ b/packages/type-plus/src/math/multiply.ts
@@ -1,5 +1,39 @@
 import type { NumericStruct } from './numeric_struct.js'
 
+/**
+ * ⚗️ *transform*
+ *
+ * `A * B` at the type level, on `number` and `bigint` literals.
+ *
+ * ⚠️ Two limits this family shares, both easy to trip:
+ *
+ * - **Only literals.** The widened `number` and `bigint` types carry no value,
+ *   so they resolve to `Fail` (`never` by default).
+ * - **A whole-number result from fractional inputs does not resolve to a
+ *   number.** It resolves to the error *string*
+ *   `"The value '4.0' cannot be represented as bigint or number"`, because the
+ *   intermediate is formatted as `4.0` and TypeScript will not parse that back
+ *   to a numeric literal. Fractional results are fine.
+ *
+ * There is no overflow guard: a result past `Number.MAX_SAFE_INTEGER` is
+ * produced anyway, and is no longer exact.
+ *
+ * @example
+ * ```ts
+ * type R = Multiply<3, 4> // 12
+ * type R = Multiply<-3, 4> // -12
+ * type R = Multiply<3, 0> // 0
+ * type R = Multiply<3n, 4n> // 12n
+ *
+ * type R = Multiply<number, 2> // never
+ *
+ * // no overflow guard
+ * type R = Multiply<9007199254740991, 2> // 18014398509481982
+ *
+ * // a whole-number result from fractional inputs
+ * type R = Multiply<0.5, 4> // "The value '2.0' cannot be represented as bigint or number"
+ * ```
+ */
 export type Multiply<A extends number | bigint, B extends number | bigint, Fail = never> = [
 	NumericStruct.FromNumeric<A, Fail>,
 	NumericStruct.FromNumeric<B, Fail>,

--- a/packages/type-plus/src/math/subtract.ts
+++ b/packages/type-plus/src/math/subtract.ts
@@ -1,5 +1,37 @@
 import type { NumericStruct } from './numeric_struct.js'
 
+/**
+ * ⚗️ *transform*
+ *
+ * `A - B` at the type level, on `number` and `bigint` literals.
+ *
+ * ⚠️ Two limits this family shares, both easy to trip:
+ *
+ * - **Only literals.** The widened `number` and `bigint` types carry no value,
+ *   so they resolve to `Fail` (`never` by default).
+ * - **A whole-number result from fractional inputs does not resolve to a
+ *   number.** It resolves to the error *string*
+ *   `"The value '4.0' cannot be represented as bigint or number"`, because the
+ *   intermediate is formatted as `4.0` and TypeScript will not parse that back
+ *   to a numeric literal. Fractional results are fine.
+ *
+ * There is no overflow guard: a result past `Number.MAX_SAFE_INTEGER` is
+ * produced anyway, and is no longer exact.
+ *
+ * @example
+ * ```ts
+ * type R = Subtract<3, 1> // 2
+ * type R = Subtract<1, 3> // -2
+ * type R = Subtract<3n, 1n> // 2n
+ * type R = Subtract<5, 1.5> // 3.5
+ * type R = Subtract<1.5, 1.4> // 0.1
+ *
+ * type R = Subtract<number, 1> // never
+ *
+ * // a whole-number result from fractional inputs
+ * type R = Subtract<1.5, 0.5> // "The value '1.0' cannot be represented as bigint or number"
+ * ```
+ */
 export type Subtract<A extends number | bigint, B extends number | bigint, Fail = never> = [
 	NumericStruct.FromNumeric<A, Fail>,
 	NumericStruct.FromNumeric<B, Fail>,
@@ -11,4 +43,20 @@ export type Subtract<A extends number | bigint, B extends number | bigint, Fail 
 		: Fail
 	: never
 
+/**
+ * ⚗️ *transform*
+ *
+ * `N - 1`. `Subtract<N, 1>` with no `Fail` parameter, so a non-literal `N`
+ * gives `never`.
+ *
+ * @example
+ * ```ts
+ * type R = Decrement<1> // 0
+ * type R = Decrement<0> // -1
+ * type R = Decrement<1.5> // 0.5
+ * type R = Decrement<1n> // 0n
+ *
+ * type R = Decrement<number> // never
+ * ```
+ */
 export type Decrement<N extends number | bigint> = Subtract<N, 1>


### PR DESCRIPTION
Slice 2 of #669. Documents **9 of the 88** undocumented exports — every one in `src/math/`.

Running the `--undocumented` report from #670's generator against this branch: **88 → 80** of 272 exported symbols with no TSDoc. (8 of the 9; see the `MathPlus` note below.)

Branched off `main`, independent of #672 (slice 1).

## Method

Every `@example` is pinned by a compiled assertion in the new `src/math/math_docs.spec.ts`, following #662 and #671. Each type was resolved with the actual checker first and the example states what came back. The edges the brief for this family asks about — negatives, zero, non-literal `number`, floats, mixed `number`/`bigint`, overflow — were probed rather than assumed, and that is how the two defects below surfaced.

## Discrepancies found

Documented as they behave, with a ⚠️ note and a pinned test. No behavior changed.

**`GreaterThan` and `Max` do not work on `bigint`**, despite both constraints reading `A extends number | bigint`. `GreaterThan` is `Subtract<A, B, 'fail'> extends infer R extends number`; for `bigint` operands the difference is a `bigint` literal, which fails the `extends number` guard, so the result is `Fail` — `never` by default.

```ts
GreaterThan<2n, 1n> // never, not true
Max<2n, 1n>         // never, not 2n
```

**Fractional arithmetic whose result is a whole number resolves to an error string**, not a number:

```ts
Subtract<1.5, 0.5>  // "The value '1.0' cannot be represented as bigint or number"
Add<1.5, 2.5>       // "The value '4.0' cannot be represented as bigint or number"
Multiply<0.5, 4>    // "The value '2.0' cannot be represented as bigint or number"
```

The intermediate is formatted as `1.0` and TypeScript will not parse that back to a numeric literal. Fractional *results* are fine (`Subtract<1.5, 1.4>` is `0.1`). This one propagates: it is also why `GreaterThan<1.5, 2.5>` and `Max<1.5, 2.5>` are `never`.

Both look like implementation bugs rather than intended limits, but changing either alters a published type's output, so they are documented and reported, not fixed.

## Also worth stating, and now stated

- **`Abs` already had a doc comment — opening with `/*`, not `/**`.** No tooling ever saw it, which is why it was on the list. Its claims are now pinned; they were correct.
- **Exact decimal, unlike the runtime.** `Add<0.1, 0.2>` is `0.3`; `0.1 + 0.2` evaluates to `0.30000000000000004`. Worth knowing before using the type to predict a runtime value.
- **Mixing `number` and `bigint` is allowed and bigint wins**: `Add<1n, 2>` is `3n`.
- **No overflow guard**: `Add<9007199254740991, 1>` is `9007199254740992` and `Multiply<9007199254740991, 2>` is `18014398509481982` — produced, but no longer exact.
- **`Increment` and `Decrement` take no `Fail` parameter**, so a non-literal operand is always `never`, with no way to choose otherwise.

## One symbol the generator will still count

`MathPlus` is documented on `src/math/math_plus.ts`, but the `--undocumented` report still lists it, so the count lands at 80 rather than 79 — the same structural issue reported in #672. `export * as MathPlus` aliases a **module** symbol and TypeScript does not expose a module's doc comment through `getDocumentationComment`; a plain leading comment, `@module` and `@packageDocumentation` all fail. It affects every `*Plus` namespace. Worth addressing on the #670 generator rather than working around here.

## Verification

- `pnpm -w turbo build lint test` — green (270 test files passed, 2 skipped).
- `pnpm --filter type-plus test:type` — green on TypeScript 5.4, 5.5, 5.6, 6.0 and 7.
- `biome check` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xn6KQWjN8xYGnwnQiCfRFD
