### PR TITLE
docs(type-plus): document the predicates and the $type branch markers

### DIFF
--- a/.changeset/nine-jars-smile.md
+++ b/.changeset/nine-jars-smile.md
@@ -1,0 +1,17 @@
+---
+'type-plus': patch
+---
+
+Document the 8 undocumented exports in `src/predicates/` and the 7 branch
+markers in `src/$type/`.
+
+Every `@example` is pinned by a compiled assertion in
+`src/predicates/predicates_docs.spec.ts` and `src/$type/$type_docs.spec.ts`.
+
+`$Then`, `$Else`, `$Selection`, `$Distributive` and `$Exact` are what the
+`$Options`/`$Branch` convention rests on, so they now say what a caller passes
+and what comes back.
+
+Six of the predicates are listed in #665 for removal or migration. Each says so
+in its own TSDoc rather than reading as current API, and none had its
+deprecation status changed here.

--- a/.changeset/nine-jars-smile.md
+++ b/.changeset/nine-jars-smile.md
@@ -13,5 +13,4 @@ Every `@example` is pinned by a compiled assertion in
 and what comes back.
 
 Six of the predicates are listed in #665 for removal or migration. Each says so
-in its own TSDoc rather than reading as current API, and none had its
-deprecation status changed here.
+in its own TSDoc rather than reading as current API.

--- a/.changeset/olive-moons-decide.md
+++ b/.changeset/olive-moons-decide.md
@@ -1,0 +1,33 @@
+---
+'type-plus': minor
+---
+
+Deprecate `NotExtendable`, `IsExtend` and `IsNotExtend`, completing the group
+`Extendable` already belonged to. Nothing is removed and no behavior changes;
+each type now names its replacement.
+
+| Deprecated | Use instead |
+| --- | --- |
+| `IsExtend<A, B, Then, Else>` | `Assignable.$<A, B, { $then: Then; $else: Else }>` |
+| `IsNotExtend<A, B, Then, Else>` | `NotAssignable.$<A, B, { $then: Then; $else: Else }>` |
+| `Extendable<A, B>` | `Assignable.$<A, B, { selection: 'filter' }>` |
+| `NotExtendable<A, B>` | `NotAssignable.$<A, B, { selection: 'filter' }>` |
+
+`#665` names the replacement as `$Assignable`, which does not exist. The `$`
+type util hanging off `Assignable` and `NotAssignable` is the equivalent, and
+the mapping above is pinned by compiled assertions in
+`src/predicates/predicates_docs.spec.ts` rather than asserted.
+
+⚠️ Migrating to plain `Assignable`/`NotAssignable` instead of the `$` member is
+**not** a rename. The plain types special-case `any`, `never` and `unknown`, so
+three inputs change answer:
+
+```ts
+IsExtend<any, number> // boolean
+Assignable<any, number> // true
+Assignable.$<any, number, {}> // boolean -- the equivalent
+```
+
+`Assignable.$` also requires its options argument explicitly (`{}` at minimum),
+and supports `{ distributive: false }`, which the deprecated four cannot
+express.

--- a/packages/type-plus/src/$type/$type_docs.spec.ts
+++ b/packages/type-plus/src/$type/$type_docs.spec.ts
@@ -1,0 +1,53 @@
+/**
+ * Pins the `@example` blocks in the `src/$type/**` TSDoc comments to the actual
+ * behavior.
+ *
+ * The branch markers and the option namespaces are what the whole
+ * `$Options`/`$Branch` convention rests on, so their examples are worth the
+ * same compiler check as the types that use them.
+ *
+ * Follows the pattern introduced for the numeric family in #662.
+ */
+import { it } from 'vitest'
+
+import { type $Else, type $Then, type FailedT, type IsNotObject, type IsObject, testType } from '../index.js'
+
+it('$Then and $Else examples in TSDoc are accurate', () => {
+	testType.equal<IsObject<{}, IsObject.$Branch>, $Then>(true)
+	testType.equal<IsObject<string, IsObject.$Branch>, $Else>(true)
+	testType.equal<IsNotObject<{}, IsNotObject.$Branch>, $Else>(true)
+
+	type Handle<T> =
+		IsObject<T, IsObject.$Branch> extends infer R
+			? R extends $Then
+				? 'an object'
+				: R extends $Else
+					? 'not an object'
+					: never
+			: never
+
+	testType.equal<Handle<{}>, 'an object'>(true)
+	testType.equal<Handle<string>, 'not an object'>(true)
+})
+
+it('$Selection examples in TSDoc are accurate', () => {
+	testType.equal<IsObject<{}>, true>(true)
+	testType.equal<IsObject<{}, { selection: 'filter' }>, {}>(true)
+	testType.equal<IsObject<{}, IsObject.$Branch>, $Then>(true)
+})
+
+it('$Distributive examples in TSDoc are accurate', () => {
+	testType.equal<IsObject<{} | 1>, boolean>(true)
+	testType.equal<IsObject<{} | 1, { distributive: false }>, false>(true)
+})
+
+it('$Exact examples in TSDoc are accurate', () => {
+	testType.equal<IsObject<{}>, true>(true)
+	testType.equal<IsObject<{}, { exact: true }>, false>(true)
+	testType.equal<IsObject<object, { exact: true }>, true>(true)
+})
+
+it('FailedT example in TSDoc is accurate', () => {
+	// the second parameter is phantom: it does not distinguish two `FailedT`
+	testType.equal<FailedT<'missing', number | string>, FailedT<'missing', boolean>>(true)
+})

--- a/packages/type-plus/src/$type/branch/$selection.ts
+++ b/packages/type-plus/src/$type/branch/$selection.ts
@@ -1,6 +1,46 @@
 import type { $Branch } from './$branch.js'
 
+/**
+ * 🧰 *type util*
+ *
+ * The marker a branching type returns for its "then" branch.
+ *
+ * Passing a type's `$Branch` options makes it return `$Then` or `$Else`
+ * instead of collapsing to `true`/`false` or to a filtered type. The caller
+ * then matches on the marker with a single conditional, which is what lets a
+ * chain of predicates run without re-evaluating the condition -- the reason
+ * `$Branch` is the recommended default for a custom type's `$Options`.
+ *
+ * `$Then` is an opaque marker, not `true`. Compare it with `extends`, never
+ * use it as a value.
+ *
+ * @example
+ * ```ts
+ * type R = IsObject<{}, IsObject.$Branch> // $Then
+ * type R = IsObject<string, IsObject.$Branch> // $Else
+ *
+ * type Handle<T> = IsObject<T, IsObject.$Branch> extends infer R
+ *   ? R extends $Then ? 'an object'
+ *   : R extends $Else ? 'not an object'
+ *   : never
+ *   : never
+ * ```
+ */
 export type $Then = $Branch<'$then'>
+
+/**
+ * 🧰 *type util*
+ *
+ * The marker a branching type returns for its "else" branch.
+ *
+ * The counterpart of `$Then`; see it for how the two are used and why.
+ *
+ * @example
+ * ```ts
+ * type R = IsObject<string, IsObject.$Branch> // $Else
+ * type R = IsNotObject<{}, IsNotObject.$Branch> // $Else
+ * ```
+ */
 export type $Else = $Branch<'$else'>
 
 declare const $then: '$then'
@@ -20,6 +60,31 @@ export namespace $Else {
 	}
 }
 
+/**
+ * 🧰 *type util*
+ *
+ * The selection (if-then-else) half of the `$Options` convention: the option
+ * shapes a branching type accepts, and the ready-made option objects a caller
+ * passes to choose a branch style.
+ *
+ * "Selection" is the structured-programming term -- sequence, selection,
+ * iteration -- so the name refers to the choice itself, not to filtering.
+ *
+ * The members a caller reaches for are `$Selection.Options` (the constraint on
+ * a type's `$O` parameter), `$Selection.Branch` (return `$Then`/`$Else`),
+ * `$Selection.Predicate` (return `true`/`false`) and `$Selection.Filter<T>`
+ * (return `T` or `never`). `Invert` and `Flip` are for building the inverse of
+ * an existing type.
+ *
+ * @example
+ * ```ts
+ * type YourType<T, $O extends $Selection.Options = $Selection.Branch> = ...
+ *
+ * type R = IsObject<{}> // true -- the predicate default
+ * type R = IsObject<{}, { selection: 'filter' }> // {}
+ * type R = IsObject<{}, IsObject.$Branch> // $Then
+ * ```
+ */
 export namespace $Selection {
 	/**
 	 * Options for selection (if-then-else) logic.

--- a/packages/type-plus/src/$type/distributive/$distributive.ts
+++ b/packages/type-plus/src/$type/distributive/$distributive.ts
@@ -2,6 +2,25 @@ import type { $ResolveOptions } from '../$resolve_options.js'
 import type { $InputOptions } from '../branch/$input_options.js'
 import type { $Else, $Then } from '../branch/$selection.js'
 
+/**
+ * 🧰 *type util*
+ *
+ * The `distributive` half of the `$Options` convention.
+ *
+ * A predicate distributes over a union by default, so a union that is only
+ * partly matched answers `boolean` rather than `true` or `false`. Setting
+ * `{ distributive: false }` asks the question of the union as a whole instead,
+ * which gives a decisive answer.
+ *
+ * `Parse` is the builder-facing member: a custom type calls it to resolve the
+ * caller's `distributive` option against the default of `true`.
+ *
+ * @example
+ * ```ts
+ * type R = IsObject<{} | 1> // boolean
+ * type R = IsObject<{} | 1, { distributive: false }> // false
+ * ```
+ */
 export namespace $Distributive {
 	/**
 	 * Options for controlling if the type is distributive.

--- a/packages/type-plus/src/$type/errors/failed.ts
+++ b/packages/type-plus/src/$type/errors/failed.ts
@@ -1,19 +1,18 @@
 declare const uniSym: unique symbol
 
 /**
+ * A failed type carrying a message, analogous to the `Error` class in
+ * JavaScript. Type-level code returns it to report why a computation could not
+ * proceed.
+ *
+ * To attach a type alongside the message, use `FailedT`, or -- better -- define
+ * your own failed type so the message can be specific.
+ *
  * @deprecated **💀 deprecated since 8.0.0**: use `$Error` instead.
  *
- * A failed type with message.
- *
- * This is analogous to the `Error` class in JavaScript.
- *
- * It can be used in type-level programming to failed an error message.
- *
- * If you want to add additional type information,
- * use `FailedT` or create your own failed type instead.
- *
+ * @example
  * ```ts
- * type T = Failed<'error message'>
+ * type R = Failed<'error message'>
  * ```
  */
 export interface Failed<Msg extends string> {
@@ -21,15 +20,19 @@ export interface Failed<Msg extends string> {
 }
 
 /**
+ * A failed type carrying a message and one additional type.
+ *
+ * The extra type parameter is phantom: it is not part of the interface's
+ * members, so two `FailedT` with the same message and different types are the
+ * same type. Defining a custom failed type gives a better message than
+ * threading a type through this one.
+ *
  * @deprecated **💀 deprecated since 8.0.0**: use `$Error` instead.
  *
- * A failed type with message and one additional type.
- *
- * Use this to add a generic type to the failed type.
- *
- * e.g. `FailedT<'missing', number | string>`
- *
- * It's recommended to create custom failed types instead of using this to provide better message.
+ * @example
+ * ```ts
+ * type R = FailedT<'missing', number | string>
+ * ```
  */
 export interface FailedT<Msg extends string, _T> {
 	[uniSym]: Msg

--- a/packages/type-plus/src/$type/exact/$exact.ts
+++ b/packages/type-plus/src/$type/exact/$exact.ts
@@ -2,6 +2,25 @@ import type { $ResolveOptions } from '../$resolve_options.js'
 import type { $InputOptions } from '../branch/$input_options.js'
 import type { $Else, $Then } from '../branch/$selection.js'
 
+/**
+ * 🧰 *type util*
+ *
+ * The `exact` half of the `$Options` convention.
+ *
+ * A predicate asks "is `T` assignable to this?" by default. Setting
+ * `{ exact: true }` asks "is `T` *exactly* this?", which is the difference
+ * between `object` and `{}`, or between `number` and `1`.
+ *
+ * `Parse` is the builder-facing member: a custom type calls it to resolve the
+ * caller's `exact` option against the default of `false`.
+ *
+ * @example
+ * ```ts
+ * type R = IsObject<{}> // true
+ * type R = IsObject<{}, { exact: true }> // false
+ * type R = IsObject<object, { exact: true }> // true
+ * ```
+ */
 export namespace $Exact {
 	/**
 	 * Options for controlling if the type perform exact comparison.

--- a/packages/type-plus/src/predicates/CanAssign.ts
+++ b/packages/type-plus/src/predicates/CanAssign.ts
@@ -54,10 +54,48 @@ export type StrictCanAssign<A, B, Then = true, Else = false> = Assignable<
 >
 
 /**
+ * 🎭 *predicate*
+ *
+ * An alias of `CanAssign<A, B, Then, Else>`, unchanged in behavior: it
+ * distributes over a union, so a partially-assignable union gives `boolean`.
+ *
+ * #665 lists this type for removal in favour of `Assignable`.
+ *
  * @deprecated use `Assignable<A, B>` instead
+ *
+ * @example
+ * ```ts
+ * type R = IsAssign<1, number> // true
+ * type R = IsAssign<boolean, boolean> // true
+ *
+ * type R = IsAssign<number | string, number> // boolean
+ * ```
  */
 export type IsAssign<A, B, Then = true, Else = false> = CanAssign<A, B, Then, Else>
 
+/**
+ * A compile-time assignability assertion, curried so `T` can be named
+ * explicitly while the subject's type is inferred.
+ *
+ * `canAssign<T>()(subject)` compiles only when `subject` is assignable to `T`,
+ * and `canAssign<T>(false)(subject)` compiles only when it is *not*. Both
+ * always return `true` at runtime -- the value is not the point, the compile
+ * error is. The return *type* is `CanAssign<S, T>`, so a partially-assignable
+ * union surfaces as `boolean` rather than `true`.
+ *
+ * Prefer `testType.*` for new assertions; this predates it.
+ *
+ * @example
+ * ```ts
+ * canAssign<{ a: string }>()({ a: 'a' }) // ok, typed true
+ * canAssign<{ a: string }>()({ a: 'a', b: 'b' }) // ok -- extra properties are fine
+ * // canAssign<{ a: string }>()({ a: 1 }) // compile error
+ *
+ * const t = canAssign<{ a: string }>(false)
+ * t({ a: 1 }) // ok -- not assignable, which is what was asserted
+ * // t({ a: '' }) // compile error
+ * ```
+ */
 export function canAssign<T>(canAssign: false): <S>(subject: NotExtendable<S, T>) => true
 export function canAssign<T>(): <S extends T>(subject: S) => CanAssign<S, T>
 export function canAssign<T>(): <S extends T>(subject: S) => any {

--- a/packages/type-plus/src/predicates/Extends.ts
+++ b/packages/type-plus/src/predicates/Extends.ts
@@ -14,7 +14,7 @@
  * everywhere except the union case above -- and there it returns the matching
  * member (`1`) rather than all of `A`, which is what a filter should do.
  *
- * @deprecated use `Assignable.$<A, B, { selection: 'filter' }>`
+ * @deprecated 💀 use `Assignable.$<A, B, { selection: 'filter' }>` instead.
  *
  * @example
  * ```ts
@@ -37,6 +37,9 @@ export type Extendable<A, B, Then = A, Else = never> = A extends B ? Then : Else
  * `NotAssignable.$<A, B, { selection: 'filter' }>`, which agrees with this
  * type except on a union, where it returns the non-matching member rather
  * than all of `A`.
+ *
+ * @deprecated 💀 **deprecated since 8.0.0**: use
+ * `NotAssignable.$<A, B, { selection: 'filter' }>` instead.
  *
  * @example
  * ```ts
@@ -63,6 +66,9 @@ export type NotExtendable<A, B, Then = A, Else = never> = A extends B ? Else : T
  * plain `Assignable` is *not* the replacement: it special-cases the special
  * types, so `Assignable<any, number>` is `true` where this is `boolean`.
  *
+ * @deprecated 💀 **deprecated since 8.0.0**: use
+ * `Assignable.$<A, B, { $then: Then; $else: Else }>` instead.
+ *
  * @example
  * ```ts
  * type R = IsExtend<1, number> // true
@@ -82,6 +88,9 @@ export type IsExtend<A, B, Then = true, Else = false> = A extends B ? Then : Els
  *
  * #665 lists this type for removal. `NotAssignable.$<A, B, { $then: Then;
  * $else: Else }>` is an exact replacement, on the same terms as `IsExtend`.
+ *
+ * @deprecated 💀 **deprecated since 8.0.0**: use
+ * `NotAssignable.$<A, B, { $then: Then; $else: Else }>` instead.
  *
  * @example
  * ```ts

--- a/packages/type-plus/src/predicates/Extends.ts
+++ b/packages/type-plus/src/predicates/Extends.ts
@@ -1,7 +1,81 @@
 /**
+ * 🌪️ *filter*
+ *
+ * `A extends B ? Then : Else`, with `Then` defaulting to `A` and `Else` to
+ * `never` -- so by default it filters rather than predicates.
+ *
+ * ⚠️ It distributes over a union, but `Then` defaults to the *whole* `A`, not
+ * the member being tested, so every surviving branch contributes all of `A`.
+ * `Extendable<1 | 'a', number>` is `1 | 'a'`, not `1`. Pass an explicit `Then`
+ * if that matters.
+ *
+ * #665 lists this type for removal in favour of `$Assignable`, which takes the
+ * modern `$Options` object.
+ *
  * @deprecated use `$Assignable`
+ *
+ * @example
+ * ```ts
+ * type R = Extendable<1, number> // 1
+ * type R = Extendable<string, number> // never
+ * type R = Extendable<string, number, 'yes', 'no'> // 'no'
+ *
+ * type R = Extendable<1 | 'a', number> // 1 | 'a'
+ * ```
  */
 export type Extendable<A, B, Then = A, Else = never> = A extends B ? Then : Else
+
+/**
+ * 🌪️ *filter*
+ *
+ * The inverse of `Extendable`: `A extends B ? Else : Then`, with `Then`
+ * defaulting to `A` and `Else` to `never`.
+ *
+ * #665 lists this type for removal in favour of `$Assignable`.
+ *
+ * @example
+ * ```ts
+ * type R = NotExtendable<1, number> // never
+ * type R = NotExtendable<string, number> // string
+ * type R = NotExtendable<string, number, 'yes', 'no'> // 'yes'
+ * ```
+ */
 export type NotExtendable<A, B, Then = A, Else = never> = A extends B ? Else : Then
+
+/**
+ * 🎭 *predicate*
+ *
+ * Validate if `A` extends `B`.
+ *
+ * Distributes over a union, so a partially-assignable union gives `boolean`
+ * rather than `true` or `false`. It does not special-case the special types:
+ * `any` gives `boolean` and `never` gives `never`.
+ *
+ * #665 lists this type for removal in favour of `$Assignable`.
+ *
+ * @example
+ * ```ts
+ * type R = IsExtend<1, number> // true
+ * type R = IsExtend<string, number> // false
+ *
+ * type R = IsExtend<1 | 'a', number> // boolean
+ * type R = IsExtend<any, number> // boolean
+ * type R = IsExtend<never, number> // never
+ * ```
+ */
 export type IsExtend<A, B, Then = true, Else = false> = A extends B ? Then : Else
+
+/**
+ * 🎭 *predicate*
+ *
+ * The inverse of `IsExtend`: validate if `A` does *not* extend `B`.
+ *
+ * #665 lists this type for removal in favour of `$Assignable`.
+ *
+ * @example
+ * ```ts
+ * type R = IsNotExtend<1, number> // false
+ * type R = IsNotExtend<string, number> // true
+ * ```
+ */
 export type IsNotExtend<A, B, Then = true, Else = false> = A extends B ? Else : Then

--- a/packages/type-plus/src/predicates/Extends.ts
+++ b/packages/type-plus/src/predicates/Extends.ts
@@ -9,10 +9,12 @@
  * `Extendable<1 | 'a', number>` is `1 | 'a'`, not `1`. Pass an explicit `Then`
  * if that matters.
  *
- * #665 lists this type for removal in favour of `$Assignable`, which takes the
- * modern `$Options` object.
+ * #665 lists this type for removal. The modern equivalent is
+ * `Assignable.$<A, B, { selection: 'filter' }>`, which agrees with this type
+ * everywhere except the union case above -- and there it returns the matching
+ * member (`1`) rather than all of `A`, which is what a filter should do.
  *
- * @deprecated use `$Assignable`
+ * @deprecated use `Assignable.$<A, B, { selection: 'filter' }>`
  *
  * @example
  * ```ts
@@ -31,7 +33,10 @@ export type Extendable<A, B, Then = A, Else = never> = A extends B ? Then : Else
  * The inverse of `Extendable`: `A extends B ? Else : Then`, with `Then`
  * defaulting to `A` and `Else` to `never`.
  *
- * #665 lists this type for removal in favour of `$Assignable`.
+ * #665 lists this type for removal. The modern equivalent is
+ * `NotAssignable.$<A, B, { selection: 'filter' }>`, which agrees with this
+ * type except on a union, where it returns the non-matching member rather
+ * than all of `A`.
  *
  * @example
  * ```ts
@@ -51,7 +56,12 @@ export type NotExtendable<A, B, Then = A, Else = never> = A extends B ? Else : T
  * rather than `true` or `false`. It does not special-case the special types:
  * `any` gives `boolean` and `never` gives `never`.
  *
- * #665 lists this type for removal in favour of `$Assignable`.
+ * #665 lists this type for removal. `Assignable.$<A, B, { $then: Then; $else:
+ * Else }>` is an exact replacement -- same answers for literals, unions,
+ * `any`, `never`, `unknown` and custom branches -- and additionally supports
+ * `{ distributive: false }`, which this type has no way to express. Note
+ * plain `Assignable` is *not* the replacement: it special-cases the special
+ * types, so `Assignable<any, number>` is `true` where this is `boolean`.
  *
  * @example
  * ```ts
@@ -70,7 +80,8 @@ export type IsExtend<A, B, Then = true, Else = false> = A extends B ? Then : Els
  *
  * The inverse of `IsExtend`: validate if `A` does *not* extend `B`.
  *
- * #665 lists this type for removal in favour of `$Assignable`.
+ * #665 lists this type for removal. `NotAssignable.$<A, B, { $then: Then;
+ * $else: Else }>` is an exact replacement, on the same terms as `IsExtend`.
  *
  * @example
  * ```ts

--- a/packages/type-plus/src/predicates/If.ts
+++ b/packages/type-plus/src/predicates/If.ts
@@ -1,1 +1,22 @@
+/**
+ * 🎭 *predicate*
+ *
+ * Selects `Then` when `Condition` is `true` and `Else` when it is `false`.
+ * The type-level `if`.
+ *
+ * It distributes, so a `Condition` of `boolean` -- the result of an
+ * undecided predicate -- yields `Then | Else` rather than either branch.
+ *
+ * #665 lists this type as still on the positional `Then`/`Else` form, awaiting
+ * migration to the `$Options` object the rest of the predicate family uses.
+ *
+ * @example
+ * ```ts
+ * type R = If<true> // true
+ * type R = If<false> // false
+ *
+ * type R = If<true, 'yes', 'no'> // 'yes'
+ * type R = If<boolean, 'yes', 'no'> // 'yes' | 'no'
+ * ```
+ */
 export type If<Condition extends boolean, Then = true, Else = false> = Condition extends true ? Then : Else

--- a/packages/type-plus/src/predicates/IsEmptyObject.ts
+++ b/packages/type-plus/src/predicates/IsEmptyObject.ts
@@ -1,2 +1,28 @@
 /* eslint-disable @typescript-eslint/ban-types */
+/**
+ * 🎭 *predicate*
+ *
+ * Validate if `T` is the empty object type `{}`, i.e. a type that both extends
+ * `{}` and is extended by it.
+ *
+ * ⚠️ `{}` in TypeScript means "anything but `null` and `undefined`", not "an
+ * object with no properties", so this is broader than the name suggests:
+ * `object` and `Record<string, never>` both pass. Primitives do not, because
+ * `{} extends number` is false.
+ *
+ * It is a plain `extends` check with no `$Options` support, and it does not
+ * special-case the special types: `never` gives `never`.
+ *
+ * @example
+ * ```ts
+ * type R = IsEmptyObject<{}> // true
+ * type R = IsEmptyObject<object> // true
+ * type R = IsEmptyObject<Record<string, never>> // true
+ *
+ * type R = IsEmptyObject<{ a: 1 }> // false
+ * type R = IsEmptyObject<number> // false
+ *
+ * type R = IsEmptyObject<never> // never
+ * ```
+ */
 export type IsEmptyObject<T> = T extends {} ? ({} extends T ? true : false) : false

--- a/packages/type-plus/src/predicates/predicates_docs.spec.ts
+++ b/packages/type-plus/src/predicates/predicates_docs.spec.ts
@@ -10,6 +10,7 @@
 import { expect, it } from 'vitest'
 
 import {
+	type Assignable,
 	canAssign,
 	type Extendable,
 	type If,
@@ -17,6 +18,7 @@ import {
 	type IsEmptyObject,
 	type IsExtend,
 	type IsNotExtend,
+	type NotAssignable,
 	type NotExtendable,
 	testType,
 } from '../index.js'
@@ -86,4 +88,56 @@ it('canAssign examples in TSDoc are accurate', () => {
 	t({ a: 1 })
 	// @ts-expect-error -- assignable, so the negative assertion fails
 	t({ a: '' })
+})
+
+/**
+ * Pins the replacement each deprecated `Extends.ts` type names in its TSDoc.
+ *
+ * #665 lists all four for removal, so the claim that a modern type reproduces
+ * them has to be checked rather than asserted -- a migration note that is
+ * wrong is worse than none. `Assignable.$` (the type util) is the equivalent,
+ * not plain `Assignable`: the latter special-cases `any`, `never` and
+ * `unknown`, which these types do not.
+ */
+it('the Extends.ts replacements named in TSDoc are exact', () => {
+	type IE<A, B, T = true, E = false> = Assignable.$<A, B, { $then: T; $else: E }>
+
+	testType.equal<IsExtend<1, number>, IE<1, number>>(true)
+	testType.equal<IsExtend<string, number>, IE<string, number>>(true)
+	testType.equal<IsExtend<1 | 'a', number>, IE<1 | 'a', number>>(true)
+	testType.equal<IsExtend<any, number>, IE<any, number>>(true)
+	testType.equal<IsExtend<never, number>, IE<never, number>>(true)
+	testType.equal<IsExtend<unknown, number>, IE<unknown, number>>(true)
+	testType.equal<IsExtend<number, any>, IE<number, any>>(true)
+	testType.equal<IsExtend<number, never>, IE<number, never>>(true)
+	testType.equal<IsExtend<{ a: 1 }, { a: number }>, IE<{ a: 1 }, { a: number }>>(true)
+	testType.equal<IsExtend<string, number, 'yes', 'no'>, IE<string, number, 'yes', 'no'>>(true)
+
+	type INE<A, B, T = true, E = false> = NotAssignable.$<A, B, { $then: T; $else: E }>
+
+	testType.equal<IsNotExtend<1, number>, INE<1, number>>(true)
+	testType.equal<IsNotExtend<string, number>, INE<string, number>>(true)
+	testType.equal<IsNotExtend<1 | 'a', number>, INE<1 | 'a', number>>(true)
+	testType.equal<IsNotExtend<any, number>, INE<any, number>>(true)
+	testType.equal<IsNotExtend<never, number>, INE<never, number>>(true)
+	testType.equal<IsNotExtend<unknown, number>, INE<unknown, number>>(true)
+	testType.equal<IsNotExtend<string, number, 'yes', 'no'>, INE<string, number, 'yes', 'no'>>(true)
+
+	// plain `Assignable` is not the replacement: it handles the special types
+	testType.equal<Assignable<any, number>, true>(true)
+	testType.equal<IsExtend<any, number>, boolean>(true)
+
+	// the filter pair agrees except on a union, where the modern type returns
+	// the matching member rather than all of `A`
+	testType.equal<Extendable<1, number>, Assignable.$<1, number, { selection: 'filter' }>>(true)
+	testType.equal<Extendable<string, number>, Assignable.$<string, number, { selection: 'filter' }>>(true)
+	testType.equal<Extendable<1 | 'a', number>, 1 | 'a'>(true)
+	testType.equal<Assignable.$<1 | 'a', number, { selection: 'filter' }>, 1>(true)
+
+	testType.equal<NotExtendable<string, number>, NotAssignable.$<string, number, { selection: 'filter' }>>(true)
+	testType.equal<NotExtendable<1 | 'a', number>, 1 | 'a'>(true)
+	testType.equal<NotAssignable.$<1 | 'a', number, { selection: 'filter' }>, 'a'>(true)
+
+	// a capability the deprecated four cannot express at all
+	testType.equal<Assignable.$<1 | 'a', number, { distributive: false }>, false>(true)
 })

--- a/packages/type-plus/src/predicates/predicates_docs.spec.ts
+++ b/packages/type-plus/src/predicates/predicates_docs.spec.ts
@@ -1,0 +1,89 @@
+/**
+ * Pins the `@example` blocks in the `src/predicates/*.ts` TSDoc comments to the
+ * actual behavior.
+ *
+ * Every assertion here mirrors a line documented in `src/predicates/*.ts`, so a
+ * doc example that drifts from the implementation fails to compile.
+ *
+ * Follows the pattern introduced for the numeric family in #662.
+ */
+import { expect, it } from 'vitest'
+
+import {
+	canAssign,
+	type Extendable,
+	type If,
+	type IsAssign,
+	type IsEmptyObject,
+	type IsExtend,
+	type IsNotExtend,
+	type NotExtendable,
+	testType,
+} from '../index.js'
+
+it('Extendable examples in TSDoc are accurate', () => {
+	testType.equal<Extendable<1, number>, 1>(true)
+	testType.equal<Extendable<string, number>, never>(true)
+	testType.equal<Extendable<string, number, 'yes', 'no'>, 'no'>(true)
+	// `Then` defaults to the whole `A`, so every surviving branch yields all of it
+	testType.equal<Extendable<1 | 'a', number>, 1 | 'a'>(true)
+})
+
+it('NotExtendable examples in TSDoc are accurate', () => {
+	testType.equal<NotExtendable<1, number>, never>(true)
+	testType.equal<NotExtendable<string, number>, string>(true)
+	testType.equal<NotExtendable<string, number, 'yes', 'no'>, 'yes'>(true)
+})
+
+it('IsExtend examples in TSDoc are accurate', () => {
+	testType.equal<IsExtend<1, number>, true>(true)
+	testType.equal<IsExtend<string, number>, false>(true)
+	testType.equal<IsExtend<1 | 'a', number>, boolean>(true)
+	testType.equal<IsExtend<any, number>, boolean>(true)
+	testType.equal<IsExtend<never, number>, never>(true)
+})
+
+it('IsNotExtend examples in TSDoc are accurate', () => {
+	testType.equal<IsNotExtend<1, number>, false>(true)
+	testType.equal<IsNotExtend<string, number>, true>(true)
+})
+
+it('IsAssign examples in TSDoc are accurate', () => {
+	testType.equal<IsAssign<1, number>, true>(true)
+	testType.equal<IsAssign<boolean, boolean>, true>(true)
+	testType.equal<IsAssign<number | string, number>, boolean>(true)
+})
+
+it('If examples in TSDoc are accurate', () => {
+	testType.equal<If<true>, true>(true)
+	testType.equal<If<false>, false>(true)
+	testType.equal<If<true, 'yes', 'no'>, 'yes'>(true)
+	testType.equal<If<boolean, 'yes', 'no'>, 'yes' | 'no'>(true)
+})
+
+it('IsEmptyObject examples in TSDoc are accurate', () => {
+	testType.equal<IsEmptyObject<{}>, true>(true)
+	// `{}` means "anything but null and undefined", so these pass too
+	testType.equal<IsEmptyObject<object>, true>(true)
+	testType.equal<IsEmptyObject<Record<string, never>>, true>(true)
+
+	testType.equal<IsEmptyObject<{ a: 1 }>, false>(true)
+	testType.equal<IsEmptyObject<number>, false>(true)
+
+	testType.equal<IsEmptyObject<never>, never>(true)
+})
+
+it('canAssign examples in TSDoc are accurate', () => {
+	const ok = canAssign<{ a: string }>()({ a: 'a' })
+	expect(ok).toBe(true)
+	testType.equal<typeof ok, true>(true)
+
+	// extra properties are fine
+	expect(canAssign<{ a: string }>()({ a: 'a', b: 'b' })).toBe(true)
+
+	const t = canAssign<{ a: string }>(false)
+	// not assignable, which is what was asserted
+	t({ a: 1 })
+	// @ts-expect-error -- assignable, so the negative assertion fails
+	t({ a: '' })
+})


### PR DESCRIPTION
Slice 3 of #669. Documents **15 of the 88** undocumented exports — all 8 in `src/predicates/` and all 7 in `src/$type/`.

Running the `--undocumented` report from #670's generator against this branch: **88 → 73** of 272 exported symbols with no TSDoc. Both families drop off the table entirely.

Branched off `main`, independent of #672 (object) and #673 (math).

## The branch markers were the point

`$Then`, `$Else`, `$Selection`, `$Distributive` and `$Exact` are what every `$Options`-taking type on the surface is documented *in terms of* — `IsObject<{}, IsObject.$Branch>` appears in dozens of examples — and until now none of the five said what it was. They are now documented from the caller's side: what you pass, what comes back, and why you would. The builder-facing members (`Parse`, `Invert`, `Flip`) are named as such rather than explained, since they are already documented individually.

`$Selection`, `$Distributive` and `$Exact` are `export namespace` declarations, so unlike the `*Plus` module aliases noted in #672 and #673 a doc comment on them registers normally.

## Deprecated exports — all four now tagged

Six of the eight predicates are enumerated in #665. Each now says so in its own TSDoc and names its replacement.

**#665 says the replacement is `$Assignable`. No such type exists.** The real equivalents are the `$` type-util members hanging off `Assignable`/`NotAssignable`, and the mapping is verified rather than asserted — 17 `testType.equal` assertions in `predicates_docs.spec.ts`, green on all five compilers:

| Deprecated | Use instead | Fidelity |
| --- | --- | --- |
| `IsExtend<A, B, Then, Else>` | `Assignable.$<A, B, { $then: Then; $else: Else }>` | exact |
| `IsNotExtend<A, B, Then, Else>` | `NotAssignable.$<A, B, { $then: Then; $else: Else }>` | exact |
| `Extendable<A, B>` | `Assignable.$<A, B, { selection: 'filter' }>` | exact except unions |
| `NotExtendable<A, B>` | `NotAssignable.$<A, B, { selection: 'filter' }>` | exact except unions |

The predicate pair matches across literals, unions, `any`, `never`, `unknown`, both argument directions and custom branches. The filter pair differs on exactly one input — `Extendable<1 | 'a', number>` is `1 | 'a'` where the modern form gives `1` — which is the `Then = A` bug already documented on `Extendable`, so the difference favours migrating.

**⚠️ The trap:** migrating to plain `Assignable` instead of `Assignable.$` is not a rename. The plain types special-case the special types, so three inputs change answer:

```ts
IsExtend<any, number>          // boolean
Assignable<any, number>        // true      <- silently different
Assignable.$<any, number, {}>  // boolean   <- the equivalent
```

Also worth knowing for the migration: `Assignable.$` has no default for its options parameter, so every call site needs `{}` at minimum; and it supports `{ distributive: false }`, which none of the deprecated four can express.

`NotExtendable`, `IsExtend` and `IsNotExtend` carried no `@deprecated` tag; they have one now (`Extendable` already did, and its wording is aligned). `since 8.0.0` is claimed only for the three tagged here — `Extendable`'s own deprecation predates this train. This part is a `minor` changeset of its own; nothing is removed and no behavior changes.

The one internal call site — `canAssign()`'s `NotExtendable<S, T>` parameter at `CanAssign.ts:99` — is left alone. Swapping it for the modern form changes that published signature's behavior on unions, which is a separate call.

`If` is #665 group B: it stays, awaiting migration to `$Options`, and is documented as current API with a note that its signature will change.

`Failed` and `FailedT` already had prose — written *inside* the `@deprecated` tag, so `getDocumentationComment` saw nothing and they counted as undocumented. The prose is moved above the tag. (Same shape as `reduceKey` in #672.)

`canAssign()` — the runtime function — is not deprecated but is built on the deprecated `CanAssign`/`NotExtendable`. Documented as the compile-time assertion helper it is, with a pointer to `testType.*` for new assertions.

## Behavior worth stating that the names do not

Written from what the compiler reports, then pinned:

- **`Extendable<1 | 'a', number>` is `1 | 'a'`, not `1`.** It distributes, but `Then` defaults to the whole `A` rather than the member under test, so every surviving branch contributes all of `A`. It does not filter a union the way the name implies.
- **`IsEmptyObject<object>` and `IsEmptyObject<Record<string, never>>` are both `true`.** `{}` in TypeScript means "anything but `null`/`undefined`", so the check is much broader than "an object with no properties". Its existing spec only tests primitives and `{ a: 1 }`, so this was never visible.
- **`FailedT`'s second parameter is phantom** — not among the interface's members, so `FailedT<'m', number>` and `FailedT<'m', string>` are the same type. Pinned with a `testType.equal`.
- `IsExtend`/`If` do not special-case the special types: `IsExtend<any, number>` is `boolean`, `IsExtend<never, number>` is `never`, `If<boolean, 'yes', 'no'>` is `'yes' | 'no'`.

Nothing here needed a behavior change, so none was made.

## Verification

- `pnpm -w turbo build lint test` — green (271 test files passed, 2 skipped).
- `pnpm --filter type-plus test:type` — green on TypeScript 5.4, 5.5, 5.6, 6.0 and 7.
- `biome check` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xn6KQWjN8xYGnwnQiCfRFD

