### PR TITLE
docs: add AGENTS.md and bridge it to Claude Code

### DIFF
--- a/.claude/skills
+++ b/.claude/skills
@@ -1,0 +1,1 @@
+../.agents/skills

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,49 @@
+# AGENTS.md
+
+`type-plus` is a TypeScript type-level library: most of what it ships are types that resolve at
+compile time and emit no runtime code.
+
+## Verification
+
+CI runs exactly `pnpm install` then `pnpm verify`. The workflow calls a reusable workflow in
+`cyberuni/.github` and names no script itself, so `pnpm verify` locally is the gate.
+
+`pnpm knip` fails on a clean `main` with pre-existing findings and is not part of `verify`. Do not
+try to fix it and do not read it as a regression.
+
+Type tests compile the suite against TypeScript 5.4, 5.5, 5.6, 6.0 and 7
+(`pnpm --filter type-plus test:type`). A change that passes on one version can fail on another; run
+all five.
+
+## Writing types
+
+Comments on types are erased from the JavaScript emit and survive only in the `.d.ts`, which never
+enters a consumer bundle. Documenting a type is free for consumers — document heavily in TSDoc.
+
+Every `@example` in a family is pinned to the implementation by `src/<family>/<family>_docs.spec.ts`
+with `testType.equal`. Changing a documented example without updating its pin fails the type tests;
+adding examples to a family that has no such file means creating one.
+
+Documentation has three homes, in descending order of trust: TSDoc on the declaration,
+`apps/website/src/content/docs/`, and the legacy `src/<family>/readme.md` tree. The last is the rot
+risk — #667 deleted 13 of its 33 pages for documenting types that no longer existed, and the
+surviving 20 are still linked from `packages/type-plus/readme.md`, so they are live and still drift.
+Prefer the first two; when you rename or remove an export, grep the readme tree for it.
+
+## Node scripts
+
+`typescript` is v7, whose npm package exposes only `version` to JS consumers. A script that needs the
+compiler API must import `ts-6.0`, the pinned alias already present for the type tests.
+
+## Git
+
+A remote branch named literally `docs` occupies that ref namespace on `origin`, so `docs/<name>`
+branches are rejected on push. Use `docs-<name>`.
+
+<!-- buddy-agent-harness:begin -->
+
+Skills are canonical in `.agents/skills/` — create and edit them there. `.claude/skills/` is a
+generated bridge to it; never write to it directly. `CLAUDE.md` is a generated pointer to this file.
+Shared instructions belong here; keep only Claude-specific notes there.
+
+<!-- buddy-agent-harness:end -->

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md


### PR DESCRIPTION
## What

- `AGENTS.md` — 49 lines, the facts an agent needs that the repo does not otherwise state.
- `CLAUDE.md` — one line, `@AGENTS.md`. Claude Code does not read `AGENTS.md`.
- `.claude/skills` → `../.agents/skills` — a tracked symlink. `.agents/skills/` was already canonical with six skills in it; Claude Code was the only harness that could not see them. Cursor, Codex and Copilot CLI read `.agents/skills/` natively and get nothing.

Produced with `buddy-agent-harness:init`.

## Why

The repo had no agent configuration at all — no `AGENTS.md`, no `CLAUDE.md`, no copilot instructions. Every trap in it therefore had to be handed over out of band or rediscovered:

- `pnpm knip` fails on a clean `main` with pre-existing findings and is not part of `verify`. Verified by running it on a bare checkout of `db936ad` — it exits 1. Without this line an agent chases it as a regression it caused.
- CI runs exactly `pnpm install` then `pnpm verify`. The workflow calls `cyberuni/.github/.github/workflows/pnpm-verify.yml@v2` and names no script itself, so the gate is not discoverable from this repo.
- A Node script needing the TypeScript compiler API cannot `import ts from 'typescript'` — v7's npm package exposes only `version` to JS consumers. It has to use the `ts-6.0` alias already present for the type tests. This one cost real time in #670.
- A remote branch named literally `docs` occupies that ref namespace on `origin`, so `docs/<name>` is rejected on push.

## What was deliberately left out

Every candidate was tested against "would the agent get this wrong, or spend tokens finding it?" Four failed:

| Cut | Because |
| --- | --- |
| pnpm / turbo / biome / vitest | one read of `package.json` |
| Conventional Commits | the husky `commit-msg` hook enforces it |
| formatting rules | `pnpm check` enforces them |
| changesets pre-mode on tag `beta` | one read of `.changeset/pre.json`, and "every published change needs a changeset" is policy, not a derivable fact |

## One correction worth noting

An earlier draft of this file claimed the `src/**/readme.md` tree "was deleted after it rotted — do not reintroduce it." That is wrong, and re-checking against `main` caught it. #667 deleted **13 of 33** pages, specifically the unreferenced ones. The other **20 still exist and are linked from `packages/type-plus/readme.md`**, the npm landing page. An agent acting on the wrong line could have deleted live files.

The file now says what is actually true — three documentation homes, with the readme tree named as the rot risk rather than as dead. That rot is real and current; it is being fixed separately.

## Verification

`pnpm check` clean. `.claude/skills` resolves to the six canonical skills. The symlink is tracked as mode `120000`, per the standard — it belongs in version control and is not gitignored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BUybspzGX8c3w7u3egBTQp