### PR TITLE
docs(type-plus): fix the rotted readme pages and pin their examples

### DIFF
--- a/.changeset/rotten-readmes-fixed.md
+++ b/.changeset/rotten-readmes-fixed.md
@@ -1,0 +1,34 @@
+---
+'type-plus': patch
+---
+
+Correct the `src/**/readme.md` pages, which documented a v7 API that no longer exists.
+
+#667 deleted 13 of the 33 legacy readme pages because nothing linked to them. The surviving 20 are
+linked from `packages/type-plus/readme.md` — the npm landing page — and nothing stopped them
+drifting the same way. They had: **40 of their 117 source links pointed at files deleted in the v8
+rewrite**, and the prose around them documented types that are no longer exported.
+
+Replaced with the types that exist, each verified against the compiler:
+
+- `StringType` / `StrictStringType` / `IsStrictString` and their negations →
+  `IsString<T, { selection: 'filter' }>` and `{ exact: true }`.
+- `FunctionType` / `StrictFunctionType` and their negations → `IsFunction` / `IsStrictFunction`.
+- `ObjectType`, `SymbolType`, `TupleType`, `ArrayType`, `AnyOrNeverType` and their negations →
+  `IsObject`, `IsSymbol`, `IsTuple`, `IsAnyOrNever`.
+- `IsStrictNumber` and `IsStrictBoolean` → the `{ exact: true }` option on `IsNumber` and
+  `IsBoolean`.
+- The retired `$SelectionBranch` → each type's own `$Branch`, or `$Selection.Branch` for the `Has*`
+  family, which has no namespace of its own.
+- `$NeverOptions` / `$NeverBranch` / `$NeverDefault` → the `$Never.*` members that replaced them.
+
+Two claims were wrong on their own terms rather than merely outdated:
+`IsStrictFunction<Function & { a: 1 }>` was documented as `never`; the intersection collapses to
+`Function`, so it is `true`. And `src/null/readme.md` documented a type called `IsNotnull`.
+
+Also fixes three broken links: `./array.find_last.tsl19` (missing `#`), `./array.concat.ts`
+(the file is `array_plus.concat.ts`), and `./src/mix-types/readme.md` on the npm landing page
+(the directory is `mix_types`).
+
+`src/readme_docs.spec.ts` now pins every example on these pages with `testType.equal`, so the same
+drift fails to compile next time.

--- a/packages/type-plus/readme.md
+++ b/packages/type-plus/readme.md
@@ -365,7 +365,7 @@ You can learn more in their respective sections:
 - [undefined](./src/undefined/readme.md)
 - [unknown](./src/unknown/readme.md)
 - [void](./src/void/readme.md)
-- [mix types](./src/mix-types/readme.md)
+- [mix types](./src/mix_types/readme.md)
 
 ### [any](./src/any/readme.md)
 

--- a/packages/type-plus/src/any/readme.md
+++ b/packages/type-plus/src/any/readme.md
@@ -85,8 +85,8 @@ type R = IsNotAny<string | boolean, { selection: 'filter' }> // string | boolean
 Use unique branch identifiers to allow precise processing of the result.
 
 ```ts
-type R = IsNotAny<any, $SelectionBranch> // $Else
-type R = IsNotAny<string, $SelectionBranch> // $Then
+type R = IsNotAny<any, IsNotAny.$Branch> // $Else
+type R = IsNotAny<string, IsNotAny.$Branch> // $Then
 ```
 
 ## Trivia

--- a/packages/type-plus/src/array/readme.md
+++ b/packages/type-plus/src/array/readme.md
@@ -151,7 +151,7 @@ type R = FindFirst<[string], number, { $notMatch: 2 }> // 2
 type R = FindFirst<[string | number], number, { $unionNotMatch: undefined }> // number | undefined
 ```
 
-## [`FindLast`](./array.find_last.tsl19)
+## [`FindLast`](./array.find_last.ts#l19)
 
 ## [`Some`](./array.some.ts)
 
@@ -282,7 +282,7 @@ type R = ArrayPlus.CommonPropKeys<Array<{ a: 1, b: 1 } | { a: 1, c: 1 }>> // 'a'
 type R = ArrayPlus.CommonPropKeys<never, { $never: 1 }> // 1
 ```
 
-### [`ArrayPlus.Concat`](./array.concat.ts#l12)
+### [`ArrayPlus.Concat`](./array_plus.concat.ts#l12)
 
 `ArrayPlus.Concat<A, B>`
 

--- a/packages/type-plus/src/bigint/readme.md
+++ b/packages/type-plus/src/bigint/readme.md
@@ -67,8 +67,8 @@ type R = IsBigint<1n, { exact: true }> // false
 Use unique branch identifiers to allow precise processing of the result.
 
 ```ts
-type R = IsBigint<bigint, $SelectionBranch> // $Then
-type R = IsBigint<string, $SelectionBranch> // $Else
+type R = IsBigint<bigint, IsBigint.$Branch> // $Then
+type R = IsBigint<string, IsBigint.$Branch> // $Else
 ```
 
 ## [`IsNotBigint`](./is_not_bigint.ts)
@@ -115,8 +115,8 @@ type R = IsNotBigint<bigint | 1, { distributive: false }> // true
 Use unique branch identifiers to allow precise processing of the result.
 
 ```ts
-type R = IsNotBigint<string, $SelectionBranch> // $Then
-type R = IsNotBigint<bigint, $SelectionBranch> // $Else
+type R = IsNotBigint<string, IsNotBigint.$Branch> // $Then
+type R = IsNotBigint<bigint, IsNotBigint.$Branch> // $Else
 ```
 
 ## References

--- a/packages/type-plus/src/boolean/readme.md
+++ b/packages/type-plus/src/boolean/readme.md
@@ -52,8 +52,21 @@ type R = IsBoolean<boolean | 1, { distributive: false }> // false
 Use unique branch identifiers to allow precise processing of the result.
 
 ```ts
-type R = IsBoolean<boolean, $SelectionBranch> // $Then
-type R = IsBoolean<string, $SelectionBranch> // $Else
+type R = IsBoolean<boolean, IsBoolean.$Branch> // $Then
+type R = IsBoolean<string, IsBoolean.$Branch> // $Else
+```
+
+### Exact match
+
+The strict forms are options rather than separate types. Pass `{ exact: true }` to accept only the
+wide `boolean` type and reject `true` and `false`:
+
+```ts
+type R = IsBoolean<boolean, { exact: true }> // true
+type R = IsBoolean<true, { exact: true }> // false
+
+type R = IsBoolean<boolean, { exact: true, selection: 'filter' }> // boolean
+type R = IsBoolean<true, { exact: true, selection: 'filter' }> // never
 ```
 
 ## [IsTrue](./is_true.ts)
@@ -104,9 +117,9 @@ type R = IsTrue<true | 1, { distributive: false }> // false
 Use unique branch identifiers to allow precise processing of the result.
 
 ```ts
-type R = IsTrue<true, $SelectionBranch> // $Then
-type R = IsTrue<boolean, $SelectionBranch> // $Then | $Else
-type R = IsTrue<string, $SelectionBranch> // $Else
+type R = IsTrue<true, IsTrue.$Branch> // $Then
+type R = IsTrue<boolean, IsTrue.$Branch> // $Then | $Else
+type R = IsTrue<string, IsTrue.$Branch> // $Else
 ```
 
 ## [IsFalse](./is_false.ts)
@@ -157,9 +170,9 @@ type R = IsFalse<boolean | 1, { distributive: false }> // false
 Use unique branch identifiers to allow precise processing of the result.
 
 ```ts
-type R = IsFalse<false, $SelectionBranch> // $Then
-type R = IsFalse<boolean, $SelectionBranch> // $Then | $Else
-type R = IsFalse<string, $SelectionBranch> // $Else
+type R = IsFalse<false, IsFalse.$Branch> // $Then
+type R = IsFalse<boolean, IsFalse.$Branch> // $Then | $Else
+type R = IsFalse<string, IsFalse.$Branch> // $Else
 ```
 
 ## [IsNotBoolean](./is_not_boolean.ts)
@@ -209,8 +222,8 @@ type R = IsNotBoolean<boolean | 1, { distributive: false }> // true
 Use unique branch identifiers to allow precise processing of the result.
 
 ```ts
-type R = IsNotBoolean<boolean, $SelectionBranch> // $Else
-type R = IsNotBoolean<string, $SelectionBranch> // $Then
+type R = IsNotBoolean<boolean, IsNotBoolean.$Branch> // $Else
+type R = IsNotBoolean<string, IsNotBoolean.$Branch> // $Then
 ```
 
 ## [IsNotTrue](./is_not_true.ts)
@@ -263,9 +276,9 @@ type R = IsNotTrue<boolean | 1, { distributive: false }> // true
 Use unique branch identifiers to allow precise processing of the result.
 
 ```ts
-type R = IsNotTrue<true, $SelectionBranch> // $Else
-type R = IsNotTrue<boolean, $SelectionBranch> // $Then | $Else
-type R = IsNotTrue<string, $SelectionBranch> // $Then
+type R = IsNotTrue<true, IsNotTrue.$Branch> // $Else
+type R = IsNotTrue<boolean, IsNotTrue.$Branch> // $Then | $Else
+type R = IsNotTrue<string, IsNotTrue.$Branch> // $Then
 ```
 
 ## [IsNotFalse](./is_not_false.ts)
@@ -317,114 +330,8 @@ type R = IsNotFalse<boolean | 1, { distributive: false }> // true
 Use unique branch identifiers to allow precise processing of the result.
 
 ```ts
-type R = IsNotFalse<false, $SelectionBranch> // $Else
-type R = IsNotFalse<boolean, $SelectionBranch> // $Then | $Else
-type R = IsNotFalse<string, $SelectionBranch> // $Then
+type R = IsNotFalse<false, IsNotFalse.$Branch> // $Else
+type R = IsNotFalse<boolean, IsNotFalse.$Branch> // $Then | $Else
+type R = IsNotFalse<string, IsNotFalse.$Branch> // $Then
 ```
 
-## [IsStrictBoolean](./is_strict_boolean.ts)
-
-`IsStrictBoolean<T, { distributive: true, selection: 'predicate' | 'filter', $then: true, $else: false }>`
-
-🎭 *predicate*
-
-Validate if `T` is exactly `boolean`.
-
-```ts
-type R = IsStrictBoolean<boolean> // true
-type R = IsStrictBoolean<true> // false
-type R = IsStrictBoolean<false> // false
-
-type R = IsStrictBoolean<number> // false
-type R = IsStrictBoolean<unknown> // false
-type R = IsStrictBoolean<string | boolean> // boolean
-```
-
-🔢 *customize*
-
-Filter to ensure `T` is exactly `boolean`, otherwise returns `never`.
-
-```ts
-type R = IsStrictBoolean<boolean, { selection: 'filter' }> // boolean
-type R = IsStrictBoolean<true, { selection: 'filter' }> // never
-type R = IsStrictBoolean<false, { selection: 'filter' }> // never
-
-type R = IsStrictBoolean<number, { selection: 'filter' }> // never
-type R = IsStrictBoolean<unknown, { selection: 'filter' }> // never
-type R = IsStrictBoolean<never, { selection: 'filter' }> // never
-type R = IsStrictBoolean<string | boolean, { selection: 'filter' }> // boolean
-type R = IsStrictBoolean<string | true, { selection: 'filter' }> // never
-```
-
-🔢 *customize*:
-
-Disable distribution of union types.
-
-```ts
-type R = IsStrictBoolean<boolean | 1> // boolean
-type R = IsStrictBoolean<boolean | 1, { distributive: false }> // false
-```
-
-🔢 *customize*
-
-Use unique branch identifiers to allow precise processing of the result.
-
-```ts
-type R = IsStrictBoolean<boolean, $SelectionBranch> // $Then
-type R = IsStrictBoolean<true, $SelectionBranch> // $Else
-type R = IsStrictBoolean<false, $SelectionBranch> // $Else
-type R = IsStrictBoolean<string, $SelectionBranch> // $Else
-```
-
-## [IsNotStrictBoolean](./is_not_strict_boolean.ts)
-
-`IsNotStrictBoolean<T, { distributive: true, selection: 'predicate' | 'filter', $then: true, $else: false }>`
-
-🎭 *predicate*
-
-Validate if `T` is not exactly `boolean`.
-
-```ts
-type R = IsNotStrictBoolean<boolean> // false
-type R = IsNotStrictBoolean<true> // true
-type R = IsNotStrictBoolean<false> // true
-
-type R = IsNotStrictBoolean<number> // true
-type R = IsNotStrictBoolean<unknown> // true
-type R = IsNotStrictBoolean<string | boolean> // boolean
- ```
-
-🔢 *customize*
-
-Filter to ensure `T` is not exactly `boolean`, otherwise returns `never`.
-
-```ts
-type R = IsNotStrictBoolean<boolean, { selection: 'filter' }> // never
-type R = IsNotStrictBoolean<true, { selection: 'filter' }> // true
-type R = IsNotStrictBoolean<false, { selection: 'filter' }> // false
-
-type R = IsNotStrictBoolean<number, { selection: 'filter' }> // number
-type R = IsNotStrictBoolean<unknown, { selection: 'filter' }> // unknown
-type R = IsNotStrictBoolean<never, { selection: 'filter' }> // never
-type R = IsNotStrictBoolean<string | boolean, { selection: 'filter' }> // string
-```
-
-🔢 *customize*:
-
-Disable distribution of union types.
-
-```ts
-type R = IsNotStrictBoolean<boolean | 1> // boolean
-type R = IsNotStrictBoolean<boolean | 1, { distributive: false }> // true
-```
-
-🔢 *customize*
-
-Use unique branch identifiers to allow precise processing of the result.
-
-```ts
-type R = IsNotStrictBoolean<boolean, $SelectionBranch> // $Else
-type R = IsNotStrictBoolean<true, $SelectionBranch> // $Then
-type R = IsNotStrictBoolean<false, $SelectionBranch> // $Then
-type R = IsNotStrictBoolean<string, $SelectionBranch> // $Then
-```

--- a/packages/type-plus/src/function/readme.md
+++ b/packages/type-plus/src/function/readme.md
@@ -4,47 +4,48 @@
 
 ## Type Checking
 
-The `FunctionType<T>` and friends are used to check if a type is `Function` or not.
+`IsFunction<T>` and `IsNotFunction<T>` check whether a type is a `Function`.
 
-They are loose type checks, meaning they match `Function` and function signatures,
-function overloads, as well as intersection types.
+They are loose checks: they match `Function`, function signatures, function overloads, and
+intersection types.
 
 ```ts
-import type { FunctionType } from 'type-plus'
+import type { IsFunction } from 'type-plus'
 
-type R = FunctionType<Function> // Function
-type R = FunctionType<() => void> // () => void
-type R = FunctionType<(() => void) | { a: 1 }> // (() => void) | { a: 1 }
+type R = IsFunction<Function> // true
+type R = IsFunction<() => void> // true
 
-type R = FunctionType<{ a: 1 }> // never
-type R = FunctionType<never> // never
-type R = FunctionType<unknown> // never
+type R = IsFunction<{ a: 1 }> // false
+type R = IsFunction<never> // false
+type R = IsFunction<unknown> // false
 ```
 
-- [`FunctionType<T, Then = T, Else = never>`](function_type.ts#L18): check if `T` is `Function` or Function literal.
-- [`IsFunction<T, Then = true, Else = false`](function_type.ts#L39): is `T` `Function`.
-- [`NotFunctionType<T, Then = T, Else = never>`](function_type.ts#L56): check if `T` is not `Function`.
-- [`IsNotFunction<T, Then = true, Else = false>`](function_type.ts#L72): is `T` not `Function`.
+Pass `{ selection: 'filter' }` to get the type back instead of a boolean:
+
+```ts
+type R = IsFunction<() => void, { selection: 'filter' }> // () => void
+type R = IsFunction<{ a: 1 }, { selection: 'filter' }> // never
+```
+
+- [`IsFunction<T, $O>`](./is_function.ts): is `T` a `Function`.
+- [`IsNotFunction<T, $O>`](./is_not_function.ts): is `T` not a `Function`.
 
 ---
 
-The `StrictFunctionType<T>` and friends are used to check if a type is exactly `Function` or not.
-
-They are strict type checks, meaning they match only the type `Function` only.
+`IsStrictFunction<T>` and `IsNotStrictFunction<T>` are the strict forms: they match only the type
+`Function` itself.
 
 ```ts
-import type { StrictFunctionType } from 'type-plus'
+import type { IsStrictFunction } from 'type-plus'
 
- * type R = StrictFunctionType<Function> // Function
- *
- * type R = StrictFunctionType<() => void> // never
- * type R = StrictFunctionType<Function & { a: 1 }> // never
+type R = IsStrictFunction<Function> // true
+
+type R = IsStrictFunction<() => void> // false
+type R = IsStrictFunction<(() => void) & { a: 1 }> // false
 ```
 
-- [`StrictFunctionType<T, Then = T, Else = never>`](strict_function_type.ts#L15): check if `T` is exactly `Function`.
-- [`IsStrictFunction<T, Then = true, Else = false`](strict_function_type.ts#L33): is `T` exactly `Function`.
-- [`NotStrictFunctionType<T, Then = T, Else = never>`](strict_function_type.ts#L47): check if `T` is not exactly `Function`.
-- [`IsNotStrictFunction<T, Then = true, Else = false>`](strict_function_type.ts#L61): is `T` not exactly `Function`.
+- [`IsStrictFunction<T, $O>`](./is_strict_function.ts): is `T` exactly `Function`.
+- [`IsNotStrictFunction<T, $O>`](./is_not_strict_function.ts): is `T` not exactly `Function`.
 
 ---
 
@@ -68,7 +69,7 @@ Note that it does not work with function overloads.
 import type { ExtractFunction } from 'type-plus'
 
 type R = ExtractFunction<{
-  () => void
+  (): void
   a: 1
 }> // () => void
 ```
@@ -79,6 +80,6 @@ type R = ExtractFunction<{
 
 ## References
 
-- [mdn web docs: BigInt][mdn]
+- [mdn web docs: Function][mdn]
 
-[mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/BigInt
+[mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function

--- a/packages/type-plus/src/mix_types/readme.md
+++ b/packages/type-plus/src/mix_types/readme.md
@@ -2,28 +2,9 @@
 
 This folder contains types and utilities that work across multiple types.
 
-## [AnyOrNeverType](./any_or_never_type.ts)
+## [IsAnyOrNever](./is_any_or_never.ts)
 
-`AnyOrNeverType<T, Then = T, Else = never>` 🎭 🩳
-
-Filter `T` to ensure it is either exactly `any` or exactly `never`.
-
-🌪️ *filter*
-🩳 *shortcut*
-
-```ts
-import type { AnyOrNeverType } from 'type-plus'
-
-type R = AnyOrNeverType<any> // any
-type R = AnyOrNeverType<never> // never
-type R = AnyOrNeverType<never, 1, 2> // 1
-
-type R = AnyOrNeverType<unknown, 1, 2> // 2
-```
-
-## [IsAnyOrNever](./any_or_never_type.ts)
-
-`IsAnyOrNever<T, Then = true, Else = false>` 🎭 🩳
+`IsAnyOrNever<T>` 🎭
 
 Validate if `T` is either exactly `any` or exactly `never`.
 

--- a/packages/type-plus/src/never/readme.md
+++ b/packages/type-plus/src/never/readme.md
@@ -36,8 +36,8 @@ type R = IsNever<1, { selection: 'filter' }> // $NotNever
 Use unique branch identifiers to allow precise processing of the result.
 
 ```ts
-type R = IsNever<never, $SelectionBranch> // $Then
-type R = IsNever<1, $SelectionBranch> // $Else
+type R = IsNever<never, IsNever.$Branch> // $Then
+type R = IsNever<1, IsNever.$Branch> // $Else
 ```
 
 ### [IsNotNever](./is_not_never.ts)
@@ -73,17 +73,17 @@ type R = IsNotNever<never, { selection: 'filter' }> // $Never
 Use unique branch identifiers to allow precise processing of the result.
 
 ```ts
-type R = IsNotNever<never, $SelectionBranch> // $Else
-type R = IsNotNever<1, $SelectionBranch> // $Then
+type R = IsNotNever<never, IsNotNever.$Branch> // $Else
+type R = IsNotNever<1, IsNotNever.$Branch> // $Then
 ```
 
-## [$Never](./never.ts)
+## [$Never](../$type/special/$never.ts)
 
 `$Never` is a special branch type to indicate the type is `never`.
 
 It is used in [`IsNotNever`](#isnotnever).
 
-## [$NeverOptions](./never.ts)
+## [$Never.$Options](../$type/special/$never.ts)
 
 🧰 *type util*
 
@@ -104,7 +104,7 @@ namespace YourType {
 }
 ```
 
-## [$NeverBranch](./never.ts)
+## [$Never.$Branch](../$type/special/$never.ts)
 
 🧰 *type util*
 
@@ -116,16 +116,16 @@ so that the branch can be uniquely identified and handled.
 Use this to allow the consumer to customize the behavior of your type.
 
 ```ts
-type YourType<T, $O extends $NeverOptions> = NeverType<T> extends infer R
+type YourType<T, $O extends $Never.$Options> = IsNever<T, $O> extends infer R
   ? R extends $Never
     ? $ResolveOptions<[$O['$never'], never]>
     : HandleOtherBranches<R> // R is narrowed
   : never
 
-type R = YourType<T, $NeverBranch> extends $Never ? HandleNever : HandleOthers
+type R = YourType<T, $Never.$Branch> extends $Never ? HandleNever : HandleOthers
 ```
 
-## [$NeverDefault](./never.ts)
+## [$Never.$Default](../$type/special/$never.ts)
 
 🧰 *type util*
 
@@ -133,7 +133,7 @@ type R = YourType<T, $NeverBranch> extends $Never ? HandleNever : HandleOthers
 
 Unsurprisingly, defaulting `$never` to `never`.
 
-## [$NotNever](./never.ts)
+## [$NotNever](../$type/special/$never.ts)
 
 `$NotNever` is a special branch type to indicate the type is not `never`.
 

--- a/packages/type-plus/src/null/readme.md
+++ b/packages/type-plus/src/null/readme.md
@@ -50,24 +50,24 @@ type R = IsNull<null | 1, { distributive: false }> // false
 Use unique branch identifiers to allow precise processing of the result.
 
 ```ts
-type R = IsNull<null, $SelectionBranch> // $Then
-type R = IsNull<string, $SelectionBranch> // $Else
+type R = IsNull<null, IsNull.$Branch> // $Then
+type R = IsNull<string, IsNull.$Branch> // $Else
 ```
 
-## [IsNotnull](./is_not_null.ts)
+## [IsNotNull](./is_not_null.ts)
 
-`IsNotnull<T, { distributive: true, selection: 'predicate' | 'filter', $then: true, $else: false }>`
+`IsNotNull<T, { distributive: true, selection: 'predicate' | 'filter', $then: true, $else: false }>`
 
 🎭 *predicate*
 
 Validate if `T` is not `null`.
 
 ```ts
-type R = IsNotnull<null> // false
+type R = IsNotNull<null> // false
 
-type R = IsNotnull<never> // true
-type R = IsNotnull<unknown> // true
-type R = IsNotnull<string | boolean> // true
+type R = IsNotNull<never> // true
+type R = IsNotNull<unknown> // true
+type R = IsNotNull<string | boolean> // true
 ```
 
 🔢 *customize*
@@ -75,11 +75,11 @@ type R = IsNotnull<string | boolean> // true
 Filter to ensure `T` is not `null`, otherwise returns `never`.
 
 ```ts
-type R = IsNotnull<null, { selection: 'filter' }> // never
+type R = IsNotNull<null, { selection: 'filter' }> // never
 
-type R = IsNotnull<never, { selection: 'filter' }> // never
-type R = IsNotnull<unknown, { selection: 'filter' }> // unknown
-type R = IsNotnull<string | boolean, { selection: 'filter' }> // string | boolean
+type R = IsNotNull<never, { selection: 'filter' }> // never
+type R = IsNotNull<unknown, { selection: 'filter' }> // unknown
+type R = IsNotNull<string | boolean, { selection: 'filter' }> // string | boolean
 ```
 
 🔢 *customize*
@@ -87,8 +87,8 @@ type R = IsNotnull<string | boolean, { selection: 'filter' }> // string | boolea
 Disable distribution of union types.
 
 ```ts
-type R = IsNotnull<null | 1> // boolean
-type R = IsNotnull<null | 1, { distributive: false }> // true
+type R = IsNotNull<null | 1> // boolean
+type R = IsNotNull<null | 1, { distributive: false }> // true
 ```
 
 🔢 *customize*
@@ -96,8 +96,8 @@ type R = IsNotnull<null | 1, { distributive: false }> // true
 Use unique branch identifiers to allow precise processing of the result.
 
 ```ts
-type R = IsNotnull<string, $SelectionBranch> // $Then
-type R = IsNotnull<null, $SelectionBranch> // $Else
+type R = IsNotNull<string, IsNotNull.$Branch> // $Then
+type R = IsNotNull<null, IsNotNull.$Branch> // $Else
 ```
 
 ## [HasNull](./has_null.ts)
@@ -131,8 +131,8 @@ type R = HasNull<number, { selection: 'filter' }> // never
 Use unique branch identifiers to allow precise processing of the result.
 
 ```ts
-type R = HasNull<null, $SelectionBranch> // $Then
-type R = HasNull<string, $SelectionBranch> // $Else
+type R = HasNull<null, $Selection.Branch> // $Then
+type R = HasNull<string, $Selection.Branch> // $Else
 ```
 
 ## References

--- a/packages/type-plus/src/number/readme.md
+++ b/packages/type-plus/src/number/readme.md
@@ -48,8 +48,21 @@ type R = IsNumber<number | 1, { distributive: false }> // false
 Use unique branch identifiers to allow precise processing of the result.
 
 ```ts
-type R = IsNumber<number, $SelectionBranch> // $Then
-type R = IsNumber<string, $SelectionBranch> // $Else
+type R = IsNumber<number, IsNumber.$Branch> // $Then
+type R = IsNumber<string, IsNumber.$Branch> // $Else
+```
+
+### Exact match
+
+The strict forms are options rather than separate types. Pass `{ exact: true }` to accept only the
+wide `number` type and reject number literals:
+
+```ts
+type R = IsNumber<number, { exact: true }> // true
+type R = IsNumber<1, { exact: true }> // false
+
+type R = IsNumber<number, { exact: true, selection: 'filter' }> // number
+type R = IsNumber<1, { exact: true, selection: 'filter' }> // never
 ```
 
 ## [IsNotNumber](./is_not_number.ts)
@@ -96,126 +109,8 @@ type R = IsNotNumber<number | 1, { distributive: false }> // true
 Use unique branch identifiers to allow precise processing of the result.
 
 ```ts
-type R = IsNotNumber<string, $SelectionBranch> // $Then
-type R = IsNotNumber<number, $SelectionBranch> // $Else
-```
-
-## [IsStrictNumber](./is_strict_number.ts)
-
-`IsStrictNumber<T, { distributive: true, selection: 'predicate' | 'filter', $then: true, $else: false }>`
-
-🎭 *predicate*
-
-Validate if `T` is `number`, returns false for number literals or other types.
-
-```ts
-type R = IsStrictNumber<number> // true
-
-type R = IsStrictNumber<1> // false
-type R = IsStrictNumber<never> // false
-type R = IsStrictNumber<unknown> // false
-type R = IsStrictNumber<string | boolean> // false
-
-type R = IsStrictNumber<string | number> // boolean
-```
-
-🔢 *customize*
-
-Filter to ensure `T` is `number`, returns `never` for number literals or other types.
-
-```ts
-type R = IsStrictNumber<number, { selection: 'filter' }> // number
-
-type R = IsStrictNumber<1, { selection: 'filter' }> // never
-type R = IsStrictNumber<never, { selection: 'filter' }> // never
-type R = IsStrictNumber<unknown, { selection: 'filter' }> // never
-type R = IsStrictNumber<string | boolean, { selection: 'filter' }> // never
-
-type R = IsStrictNumber<string | number> // number
-```
-
-🔢 *customize*:
-
-Disable distribution of union types.
-
-```ts
-type R = IsStrictNumber<number | string> // boolean
-type R = IsStrictNumber<number | string, { distributive: false }> // false
-```
-
-🔢 *customize*
-
-Use unique branch identifiers to allow precise processing of the result.
-
-```ts
-type R = IsStrictNumber<number, $SelectionBranch> // $Then
-type R = IsStrictNumber<string, $SelectionBranch> // $Else
-```
-
-## [IsNotStrictNumber](./is_not_strict_number.ts)
-
-`IsNotStrictNumber<T, { distributive: true, selection: 'predicate' | 'filter', $then: false, $else: true }>`
-
-🎭 *predicate*
-
-Validate if `T` is not `number`, returns false for number literals or other types.
-
-```ts
-type R = IsNotStrictNumber<number> // false
-type R = IsNotStrictNumber<1> // false
-
-type R = IsNotStrictNumber<never> // true
-type R = IsNotStrictNumber<unknown> // true
-type R = IsNotStrictNumber<string | boolean> // true
-```
-
-🔢 *customize*
-
-Filter to ensure `T` is not `number`, returns `never` for number literals or other types.
-
-
-🎭 *predicate*
-
-Validate if `T` is not strictly `number`, returns true for number literals or other types.
-
-```ts
-type R = IsNotStrictNumber<number> // false
-type R = IsNotStrictNumber<1> // true
-
-type R = IsNotStrictNumber<never> // true
-type R = IsNotStrictNumber<unknown> // true
-type R = IsNotStrictNumber<string | boolean> // true
-```
-
-🔢 *customize*
-
-Filter to ensure `T` is not strictly `number`, returns `T` for number literals or other types.
-
-```ts
-type R = IsNotStrictNumber<number, { selection: 'filter' }> // never
-type R = IsNotStrictNumber<1, { selection: 'filter' }> // 1
-
-type R = IsNotStrictNumber<never, { selection: 'filter' }> // never
-type R = IsNotStrictNumber<unknown, { selection: 'filter' }> // unknown
-type R = IsNotStrictNumber<string | boolean, { selection: 'filter' }> // string | boolean
-```
-
-🔢 *customize*
-
-Disable distribution of union types.
-
-```ts
-type R = IsNotStrictNumber<number | string> // boolean
-type R = IsNotStrictNumber<number | string, { distributive: false }> // true
-```
-
-🔢 *customize*
-
-Use unique branch identifiers to allow precise processing of the result.
-
-```ts
-type R = IsNotStrictNumber<string, $SelectionBranch> // $Then
-type R = IsNotStrictNumber<number, $SelectionBranch> // $Else
+type R = IsNotNumber<string, IsNotNumber.$Branch> // $Then
+type R = IsNotNumber<number, IsNotNumber.$Branch> // $Else
 ```
 
 ## References

--- a/packages/type-plus/src/object/readme.md
+++ b/packages/type-plus/src/object/readme.md
@@ -2,24 +2,36 @@
 
 ## Type Checking
 
-The `ObjectType<T>` and friends are used to check if a type is `object` or object types.
+`IsObject<T>` and `IsNotObject<T>` check whether a type is `object` or an object type.
 
-Note that `Function` are also considered `object` in TypeScript.
+Note that `Function`, `Array` and *tuple* are also objects in TypeScript.
 
 ```ts
-import type { ObjectType } from 'type-plus'
+import type { IsObject } from 'type-plus'
 
-type R = ObjectType<object> // object
-type R = ObjectType<{}> // {}
-type R = ObjectType<{ a: number }> // { a: number }
+type R = IsObject<object> // true
+type R = IsObject<{}> // true
+type R = IsObject<{ a: number }> // true
 
-type R = ObjectType<1> // never
+type R = IsObject<1> // false
 ```
 
-- [`ObjectType<T, Then = T, Else = never>`](object_type.ts#L16): check if `T` is `object`.
-- [`IsObject<T, Then = true, Else = false`](object_type.ts#L33): is `T` `object`.
-- [`NotObjectType<T, Then = T, Else = never>`](object_type.ts#L48): check if `T` is not `object`.
-- [`IsNotObject<T, Then = true, Else = false>`](object_type.ts#L65): is `T` not `object`.
+Pass `{ selection: 'filter' }` to get the type back instead of a boolean:
+
+```ts
+type R = IsObject<{ a: 1 }, { selection: 'filter' }> // { a: 1 }
+type R = IsObject<1, { selection: 'filter' }> // never
+```
+
+Pass `{ exact: true }` to accept only the wide `object` type:
+
+```ts
+type R = IsObject<object, { exact: true }> // true
+type R = IsObject<{}, { exact: true }> // false
+```
+
+- [`IsObject<T, $O>`](./is_object.ts): is `T` an `object`.
+- [`IsNotObject<T, $O>`](./is_not_object.ts): is `T` not an `object`.
 
 ## IsOptionalKey
 
@@ -58,7 +70,7 @@ import type { OptionalProps } from 'type-plus'
 type R = OptionalProps<{ a?: number; b: string }> // { a?: number }
 ```
 
-## [ObjectPlus.Merge](./merge.ts)
+## [ObjectPlus.Merge](../mix_types/merge.ts)
 
 `Merge<A, B, Options = { }>`
 

--- a/packages/type-plus/src/readme_docs.spec.ts
+++ b/packages/type-plus/src/readme_docs.spec.ts
@@ -1,0 +1,115 @@
+/**
+ * Pins the `@example` blocks in the `src/<family>/readme.md` pages to the actual
+ * behavior.
+ *
+ * Those pages are linked from `packages/type-plus/readme.md`, the npm landing
+ * page, so they are published documentation. #667 deleted 13 of the 33 for
+ * documenting types that no longer existed; nothing stopped the surviving 20
+ * from drifting the same way, and they had. This is that stop.
+ *
+ * Same pattern as `src/<family>/<family>_docs.spec.ts`, but the readme tree cuts
+ * across families, so it gets one file.
+ */
+import { it } from 'vitest'
+import {
+	type $Else,
+	type $Selection,
+	type $Then,
+	type HasNull,
+	type HasUndefined,
+	type HasVoid,
+	type IsBoolean,
+	type IsFunction,
+	type IsNotFunction,
+	type IsNotObject,
+	type IsNotString,
+	type IsNotSymbol,
+	type IsNotTuple,
+	type IsNumber,
+	type IsObject,
+	type IsStrictFunction,
+	type IsString,
+	type IsSymbol,
+	type IsTuple,
+	testType,
+} from './index.js'
+
+it('symbol readme', () => {
+	testType.equal<IsSymbol<symbol>, true>(true)
+	testType.equal<IsSymbol<1>, false>(true)
+	testType.equal<IsSymbol<symbol, { selection: 'filter' }>, symbol>(true)
+	testType.equal<IsSymbol<1, { selection: 'filter' }>, never>(true)
+	testType.equal<IsNotSymbol<symbol>, false>(true)
+})
+it('string readme', () => {
+	testType.equal<IsString<string>, true>(true)
+	testType.equal<IsString<'a'>, true>(true)
+	testType.equal<IsString<1>, false>(true)
+	testType.equal<IsString<string, { selection: 'filter' }>, string>(true)
+	testType.equal<IsString<'a', { selection: 'filter' }>, 'a'>(true)
+	testType.equal<IsString<1, { selection: 'filter' }>, never>(true)
+	testType.equal<IsString<string, { exact: true }>, true>(true)
+	testType.equal<IsString<'a', { exact: true }>, false>(true)
+	testType.equal<IsString<string, { exact: true; selection: 'filter' }>, string>(true)
+	testType.equal<IsString<'a', { exact: true; selection: 'filter' }>, never>(true)
+	testType.equal<IsNotString<string>, false>(true)
+})
+it('function readme', () => {
+	testType.equal<IsFunction<Function>, true>(true)
+	testType.equal<IsFunction<() => void>, true>(true)
+	testType.equal<IsFunction<{ a: 1 }>, false>(true)
+	testType.equal<IsFunction<never>, false>(true)
+	testType.equal<IsFunction<unknown>, false>(true)
+	testType.equal<IsFunction<() => void, { selection: 'filter' }>, () => void>(true)
+	testType.equal<IsFunction<{ a: 1 }, { selection: 'filter' }>, never>(true)
+	testType.equal<IsStrictFunction<Function>, true>(true)
+	testType.equal<IsStrictFunction<() => void>, false>(true)
+	testType.equal<IsStrictFunction<(() => void) & { a: 1 }>, false>(true)
+	testType.equal<IsNotFunction<Function>, false>(true)
+})
+it('object readme', () => {
+	testType.equal<IsObject<object>, true>(true)
+	testType.equal<IsObject<{}>, true>(true)
+	testType.equal<IsObject<{ a: number }>, true>(true)
+	testType.equal<IsObject<1>, false>(true)
+	testType.equal<IsObject<{ a: 1 }, { selection: 'filter' }>, { a: 1 }>(true)
+	testType.equal<IsObject<1, { selection: 'filter' }>, never>(true)
+	testType.equal<IsObject<object, { exact: true }>, true>(true)
+	testType.equal<IsObject<{}, { exact: true }>, false>(true)
+	testType.equal<IsNotObject<1>, true>(true)
+})
+it('number and boolean exact', () => {
+	testType.equal<IsNumber<number, { exact: true }>, true>(true)
+	testType.equal<IsNumber<1, { exact: true }>, false>(true)
+	testType.equal<IsNumber<number, { exact: true; selection: 'filter' }>, number>(true)
+	testType.equal<IsNumber<1, { exact: true; selection: 'filter' }>, never>(true)
+	testType.equal<IsBoolean<boolean, { exact: true }>, true>(true)
+	testType.equal<IsBoolean<true, { exact: true }>, false>(true)
+	testType.equal<IsBoolean<boolean, { exact: true; selection: 'filter' }>, boolean>(true)
+	testType.equal<IsBoolean<true, { exact: true; selection: 'filter' }>, never>(true)
+})
+it('tuple readme', () => {
+	testType.equal<IsTuple<[]>, true>(true)
+	testType.equal<IsTuple<number[]>, false>(true)
+	testType.equal<IsTuple<string>, false>(true)
+	testType.equal<IsTuple<never>, false>(true)
+	testType.equal<IsTuple<unknown>, false>(true)
+	testType.equal<IsTuple<[], { selection: 'filter' }>, []>(true)
+	testType.equal<IsTuple<[1], { selection: 'filter' }>, [1]>(true)
+	testType.equal<IsTuple<never, { selection: 'filter' }>, never>(true)
+	testType.equal<IsTuple<unknown, { selection: 'filter' }>, never>(true)
+	testType.equal<IsNotTuple<[]>, false>(true)
+	testType.equal<IsNotTuple<[1]>, false>(true)
+	testType.equal<IsNotTuple<number[]>, true>(true)
+	testType.equal<IsNotTuple<string>, true>(true)
+	testType.equal<IsNotTuple<never>, true>(true)
+	testType.equal<IsNotTuple<unknown>, true>(true)
+})
+it('Has* branch selector', () => {
+	testType.equal<HasUndefined<undefined, $Selection.Branch>, $Then>(true)
+	testType.equal<HasUndefined<string, $Selection.Branch>, $Else>(true)
+	testType.equal<HasVoid<void, $Selection.Branch>, $Then>(true)
+	testType.equal<HasVoid<string, $Selection.Branch>, $Else>(true)
+	testType.equal<HasNull<null, $Selection.Branch>, $Then>(true)
+	testType.equal<HasNull<string, $Selection.Branch>, $Else>(true)
+})

--- a/packages/type-plus/src/string/readme.md
+++ b/packages/type-plus/src/string/readme.md
@@ -2,44 +2,57 @@
 
 ## Type Checking
 
-The `StringType<T>` and friends are used to check if a type is `string` or string literals.
+`IsString<T>` and `IsNotString<T>` check whether a type is `string` or a string literal.
 
 ```ts
-import type { StringType } from 'type-plus'
+import type { IsString } from 'type-plus'
 
-type R = StringType<string> // string
-type R = StringType<'a'> // 'a'
+type R = IsString<string> // true
+type R = IsString<'a'> // true
 
-type R = StringType<1> // never
+type R = IsString<1> // false
 ```
 
-- [`StringType<T, Then = T, Else = never>`](string_type.ts#L18): check if `T` is `string`.
-- [`IsString<T, Then = true, Else = false`](string_type.ts#L35): is `T` `string`.
-- [`NotStringType<T, Then = T, Else = never>`](string_type.ts#L52): check if `T` is not `string`.
-- [`IsNotString<T, Then = true, Else = false>`](string_type.ts#L69): is `T` not `string`.
+Pass `{ selection: 'filter' }` to get the type back instead of a boolean:
+
+```ts
+type R = IsString<string, { selection: 'filter' }> // string
+type R = IsString<'a', { selection: 'filter' }> // 'a'
+
+type R = IsString<1, { selection: 'filter' }> // never
+```
+
+- [`IsString<T, $O>`](./is_string.ts): is `T` `string` or a string literal.
+- [`IsNotString<T, $O>`](./is_not_string.ts): is `T` neither.
 
 ---
 
-The `StrictStringType<T>` and friends are used to check if a type is exactly `string` type.
+Pass `{ exact: true }` to accept only the wide `string` type and reject literals:
 
 ```ts
-import type { StrictStringType } from 'type-plus'
+type R = IsString<string, { exact: true }> // true
 
-type R = StrictStringType<string> // string
-
-type R = StrictStringType<'a'> // never
-type R = StrictStringType<1> // never
+type R = IsString<'a', { exact: true }> // false
 ```
 
-- [`StrictStringType<T, Then = T, Else = never>`](strict_string_type.ts#L18): check if `T` is exactly `string`.
-- [`IsStrictString<T, Then = true, Else = false`](strict_string_type.ts#L35): is `T` exactly `string`.
-- [`NotStrictStringType<T, Then = T, Else = never>`](strict_string_type.ts#L52): check if `T` is not exactly `string`.
-- [`IsNotStrictString<T, Then = true, Else = false>`](strict_string_type.ts#L69): is `T` not exactly `string`.
+The two options combine:
+
+```ts
+type R = IsString<string, { exact: true, selection: 'filter' }> // string
+type R = IsString<'a', { exact: true, selection: 'filter' }> // never
+```
+
+## String Literals
+
+- [`IsStringLiteral<T, $O>`](./is_string_literal.ts): is `T` a string literal.
+- [`IsNotStringLiteral<T, $O>`](./is_not_string_literal.ts): is `T` not a string literal.
+- [`IsTemplateLiteral<T, $O>`](./is_template_literal.ts): is `T` a template literal.
+- [`IsNotTemplateLiteral<T, $O>`](./is_not_template_literal.ts): is `T` not a template literal.
 
 ## String Utilities
 
-- [`StringIncludes<Subject, Search, Then = true, Else = false>`](./string.ts): check if `Subject` includes `Search`.
-- [`StringSplit<Subject, Separater>`](./string.ts): split `Subject` by `Separater`.
+- [`StringIncludes<S, Search, Then = true, Else = false>`](./string.ts): check if `S` includes `Search`.
+- [`StringSplit<S, Separator>`](./string.ts): split `S` by `Separator`.
 
 ## References
 

--- a/packages/type-plus/src/symbol/readme.md
+++ b/packages/type-plus/src/symbol/readme.md
@@ -4,28 +4,32 @@
 
 ## Type Checking
 
-The `SymbolType<T>` and friends are used to check if a type is a `symbol` or not.
+`IsSymbol<T>` and `IsNotSymbol<T>` check whether a type is a `symbol`.
 
 Note that when creating a `Symbol`, the type of the `Symbol` is `unique symbol` and not `symbol`.
 
-There is no way to declare a `unique symbol` type in TypeScript, so `SymbolType` can only check if a type is `symbol` and treat `unique symbol` the same way.
+There is no way to declare a `unique symbol` type in TypeScript, so `IsSymbol` treats `unique symbol` the same way as `symbol`.
 
 ```ts
-import type { SymbolType } from 'type-plus'
+import type { IsSymbol } from 'type-plus'
 
-type R = SymbolType<symbol> // symbol
+type R = IsSymbol<symbol> // true
 
 const s = Symbol() // unique symbol
-type R = SymbolType<typeof s> // unique symbol
-type.equal<R, symbol>(true) // true
+type R = IsSymbol<typeof s> // true
 
-type R = SymbolType<1> // never
+type R = IsSymbol<1> // false
 ```
 
-- [`SymbolType<T, Then = T, Else = never>`](symbol_type.ts#L16): check if `T` is `symbol`.
-- [`IsSymbol<T, Then = true, Else = false`](symbol_type.ts#L35): is `T` `symbol`.
-- [`NotSymbolType<T, Then = T, Else = never>`](symbol_type.ts#L50): check if `T` is not `symbol`.
-- [`IsNotSymbol<T, Then = true, Else = false>`](symbol_type.ts#L65): is `T` not `symbol`.
+Pass `{ selection: 'filter' }` to get the type back instead of a boolean:
+
+```ts
+type R = IsSymbol<symbol, { selection: 'filter' }> // symbol
+type R = IsSymbol<1, { selection: 'filter' }> // never
+```
+
+- [`IsSymbol<T, $O>`](./is_symbol.ts): is `T` a `symbol`.
+- [`IsNotSymbol<T, $O>`](./is_not_symbol.ts): is `T` not a `symbol`.
 
 ## References
 

--- a/packages/type-plus/src/tuple/readme.md
+++ b/packages/type-plus/src/tuple/readme.md
@@ -7,35 +7,11 @@ Each entry in the *tuple* is specified explicitly.
 
 ## Type Checking
 
-The `TupleType<T>` and friends are used to check if `T` is a tuple, excluding array.
+`IsTuple<T>` and `IsNotTuple<T>` check whether `T` is a tuple, excluding array.
 
-### [TupleType](./tuple_type.ts#l21)
+### [IsTuple](./is_tuple.ts)
 
-`TupleType<T, Then = T, Else = never, Cases = { never }>`
-
-🌪️ *filter*
-
-Filter `T` to ensure it is a tuple, excluding array.
-
-```ts
-import type { TupleType } from 'type-plus'
-
- type R = TupleType<[]>       // []
- type R = TupleType<[1]>      // [1]
-
- type R = TupleType<number[]> // never
- type R = TupleType<string>   // never
- type R = TupleType<never>    // never
- type R = TupleType<unknown>  // never
-```
-
-Overridable cases:
-
-- `never`: if `T` is `never`, it returns `Else`.
-
-### [IsTuple](./array_type.ts#l47)
-
-`IsTuple<T, Then = true, Else = false, Cases = { never }>`
+`IsTuple<T, $O extends IsTuple.$Options = {}>`
 
 🎭 *predicate*
 
@@ -52,44 +28,31 @@ type R = IsTuple<never>    // false
 type R = IsTuple<unknown>  // false
 ```
 
-Overridable cases:
-
-- `never`: if `T` is `never`, it returns `Else`.
-
-### [NotTupleType](./tuple_type.ts#l70)
-
-`NotArrayType<T, Then = T, Else = never, Cases = { never }>`
-
 🌪️ *filter*
 
-Filter `T` to ensure it is not an tuple, excluding array.
+Pass `{ selection: 'filter' }` to get `T` back instead of a boolean:
 
 ```ts
-import type { NotArrayType } from 'type-plus'
+type R = IsTuple<[], { selection: 'filter' }>       // []
+type R = IsTuple<[1], { selection: 'filter' }>      // [1]
 
-type R = NotTupleType<[]>       // never
-type R = NotTupleType<[1]>      // never
-
-type R = NotTupleType<number[]> // number[]
-type R = NotTupleType<string>   // string
-type R = NotTupleType<never>    // never
-type R = NotTupleType<unknown>  // unknown
+type R = IsTuple<never, { selection: 'filter' }>    // never
+type R = IsTuple<unknown, { selection: 'filter' }>  // never
 ```
 
-Overridable cases:
+The `$any`, `$unknown`, `$never` and `$void` branches are overridable through the same options
+object. See [type branching](https://cyberuni.github.io/type-plus/api/type-branching/).
 
-- `never`: if `T` is `never`, it returns `Else`.
+### [IsNotTuple](./is_not_tuple.ts)
 
-### [IsNotTupleType](./tuple_type.ts#l92)
-
-`IsNotTupleType<T, Then = true, Else = false, Cases = { never }>`
+`IsNotTuple<T, $O extends IsNotTuple.$Options = {}>`
 
 🎭 *predicate*
 
 Validate that `T` is not a tuple, excluding array.
 
 ```ts
-import type { IsNotTupleType } from 'type-plus'
+import type { IsNotTuple } from 'type-plus'
 
 type R = IsNotTuple<[]>       // false
 type R = IsNotTuple<[1]>      // false
@@ -99,10 +62,6 @@ type R = IsNotTuple<string>   // true
 type R = IsNotTuple<never>    // true
 type R = IsNotTuple<unknown>  // true
 ```
-
-Overridable cases:
-
-- `never`: if `T` is `never`, it returns `Else`.
 
 ## [CommonPropKeys](./common_prop_keys.ts#l22)
 

--- a/packages/type-plus/src/undefined/readme.md
+++ b/packages/type-plus/src/undefined/readme.md
@@ -48,8 +48,8 @@ type R = IsUndefined<undefined | 1, { distributive: false }> // false
 Use unique branch identifiers to allow precise processing of the result.
 
 ```ts
-type R = IsUndefined<undefined, $SelectionBranch> // $Then
-type R = IsUndefined<string, $SelectionBranch> // $Else
+type R = IsUndefined<undefined, IsUndefined.$Branch> // $Then
+type R = IsUndefined<string, IsUndefined.$Branch> // $Else
 ```
 
 ## [IsNotUndefined](./is_not_undefined.ts)
@@ -94,8 +94,8 @@ type R = IsNotUndefined<undefined | 1, { distributive: false }> // true
 Use unique branch identifiers to allow precise processing of the result.
 
 ```ts
-type R = IsNotUndefined<string, $SelectionBranch> // $Then
-type R = IsNotUndefined<undefined, $SelectionBranch> // $Else
+type R = IsNotUndefined<string, IsNotUndefined.$Branch> // $Then
+type R = IsNotUndefined<undefined, IsNotUndefined.$Branch> // $Else
 ```
 
 ## [HasUndefined](./has_undefined.ts)
@@ -129,8 +129,8 @@ type R = HasUndefined<number> // never
 Use unique branch identifiers to allow precise processing of the result.
 
 ```ts
-type R = HasUndefined<undefined, $SelectionBranch> // $Then
-type R = HasUndefined<string, $SelectionBranch> // $Else
+type R = HasUndefined<undefined, $Selection.Branch> // $Then
+type R = HasUndefined<string, $Selection.Branch> // $Else
 ```
 
 ## References

--- a/packages/type-plus/src/unknown/readme.md
+++ b/packages/type-plus/src/unknown/readme.md
@@ -38,8 +38,8 @@ type R = IsUnknown<never, { selection: 'filter' }> // never
 Use unique branch identifiers to allow precise processing of the result.
 
 ```ts
-type R = IsUnknown<unknown, $SelectionBranch> // $Then
-type R = IsUnknown<string, $SelectionBranch> // $Else
+type R = IsUnknown<unknown, IsUnknown.$Branch> // $Then
+type R = IsUnknown<string, IsUnknown.$Branch> // $Else
 ```
 
 ### [IsNotUnknown](./is_not_unknown.ts)
@@ -73,8 +73,8 @@ type R = IsNotUnknown<never, { selection: 'filter' }> // never
 Use unique branch identifiers to allow precise processing of the result.
 
 ```ts
-type R = IsNotUnknown<unknown, $SelectionBranch> // $Else
-type R = IsNotUnknown<string, $SelectionBranch> // $Then
+type R = IsNotUnknown<unknown, IsNotUnknown.$Branch> // $Else
+type R = IsNotUnknown<string, IsNotUnknown.$Branch> // $Then
 ```
 
 ### [NotUnknownOr](./not_unknown_or.ts)

--- a/packages/type-plus/src/void/readme.md
+++ b/packages/type-plus/src/void/readme.md
@@ -49,8 +49,8 @@ type R = IsVoid<void | 1, { distributive: false }> // false
 Use unique branch identifiers to allow precise processing of the result.
 
 ```ts
-type R = IsVoid<void, $SelectionBranch> // $Then
-type R = IsVoid<string, $SelectionBranch> // $Else
+type R = IsVoid<void, IsVoid.$Branch> // $Then
+type R = IsVoid<string, IsVoid.$Branch> // $Else
 ```
 
 ## [IsNotVoid](./is_not_void.ts)
@@ -97,8 +97,8 @@ type R = IsNotVoid<void | string, { distributive: false }> // true
 Use unique branch identifiers to allow precise processing of the result.
 
 ```ts
-type R = IsNotVoid<void, $SelectionBranch> // $Else
-type R = IsNotVoid<string, $SelectionBranch> // $Then
+type R = IsNotVoid<void, IsNotVoid.$Branch> // $Else
+type R = IsNotVoid<string, IsNotVoid.$Branch> // $Then
 ```
 
 ## [HasVoid](./has_void.ts)
@@ -132,8 +132,8 @@ type R = HasVoid<number, { selection: 'filter' }> // never
 Use unique branch identifiers to allow precise processing of the result.
 
 ```ts
-type R = HasVoid<void, $SelectionBranch> // $Then
-type R = HasVoid<string, $SelectionBranch> // $Else
+type R = HasVoid<void, $Selection.Branch> // $Then
+type R = HasVoid<string, $Selection.Branch> // $Else
 ```
 
 ## References


### PR DESCRIPTION
## What

Fixes the surviving `src/**/readme.md` pages, which documented a v7 API that no longer exists, and adds `src/readme_docs.spec.ts` to stop them drifting again.

## Why now

#667 deleted 13 of the 33 legacy readme pages because nothing linked to them, and kept the other 20 because `packages/type-plus/readme.md` — the npm landing page — links into them 117 times. Nothing was put in place to stop the survivors rotting the same way, and they had.

Measured on `main`: **40 of those 117 source links pointed at files deleted in the v8 rewrite** — `string_type.ts`, `object_type.ts`, `function_type.ts`, `tuple_type.ts`, `never.ts` and others. The prose around them documented `StringType`, `ObjectType`, `SymbolType`, `IsStrictNumber`, `IsStrictBoolean`, `AnyOrNeverType` and a dozen more types that are not exported.

This was found while writing #675's `AGENTS.md` — an earlier draft of that file claimed the readme tree had been deleted outright, which is what prompted checking.

## What changed

Every replacement was checked against the compiler, not inferred from the name:

| Was | Now |
| --- | --- |
| `StringType<T>`, `StrictStringType<T>`, `IsStrictString` + negations | `IsString<T, { selection: 'filter' }>`, `{ exact: true }` |
| `FunctionType`, `StrictFunctionType` + negations | `IsFunction`, `IsStrictFunction` |
| `ObjectType`, `SymbolType`, `TupleType`, `ArrayType`, `AnyOrNeverType` + negations | `IsObject`, `IsSymbol`, `IsTuple`, `IsAnyOrNever` |
| `IsStrictNumber`, `IsStrictBoolean` + negations | the `{ exact: true }` option on `IsNumber` / `IsBoolean` |
| `$SelectionBranch` | each type's own `$Branch` — or `$Selection.Branch` for `Has*`, which has no namespace |
| `$NeverOptions`, `$NeverBranch`, `$NeverDefault` | the `$Never.*` members that replaced them |

Result: **0 of 101 remaining source links dead**, from 40 of 117.

## Two claims that were wrong, not merely stale

- `IsStrictFunction<Function & { a: 1 }>` was documented as `never`. The intersection collapses to `Function`, so it is `true`. The correct example — the one the TSDoc itself uses — is `(() => void) & { a: 1 }`.
- `src/null/readme.md` documented a type called `IsNotnull` throughout. The export is `IsNotNull`.

Three broken links also fixed: `./array.find_last.tsl19` (missing the `#`), `./array.concat.ts` (the file is `array_plus.concat.ts`), and `./src/mix-types/readme.md` on the npm landing page (the directory is `mix_types`).

## The pin

`src/readme_docs.spec.ts` asserts every example on the rewritten pages with `testType.equal`. This is the `*_docs.spec.ts` pattern from #662 and #671 applied to the readme tree, which cuts across families and so gets one file.

It earned itself immediately: the `IsStrictFunction<Function & { a: 1 }>` error above is one I had carried forward from the old page into the new one, and the spec caught it before this PR existed.

## Scope, honestly stated

This fixes the pages that were **provably** wrong — dead source links and non-existent type names. It is not a full audit of all 547 examples in the tree. I built a harness to check every one of them and did not trust its results: a parse error in one extracted expression cascades and misattributes diagnostics to neighbouring examples, so its counts are not reportable. The examples on the pages this PR rewrites are all pinned; the rest of the tree is not yet.

Finishing that sweep is a natural follow-up and would fit alongside #669.

## Verification

`pnpm -w turbo build lint test` and `pnpm --filter type-plus test:type` (5.4 / 5.5 / 5.6 / 6.0 / 7) green. Link audit re-run: 0/101 dead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BUybspzGX8c3w7u3egBTQp