### PR TITLE
fix(type-plus): drop `readonly` when Merge takes the disjoint path

### DIFF
--- a/.changeset/getter-merge-598.md
+++ b/.changeset/getter-merge-598.md
@@ -1,0 +1,18 @@
+---
+'type-plus': patch
+---
+
+Fix `Merge` and `ObjectPlus.Merge` dropping `readonly` when the two types are disjoint.
+
+`{ ...a, ...b }` copies property values onto a fresh object, so the result is always
+writable. The disjoint fast path returned `A & B` unchanged, which kept `readonly` from
+either side. Because a get-only accessor is a `readonly` property, that made a getter
+merge in as a read-only property instead of a plain data property:
+
+```ts
+type R = Merge<{ get config(): ResolvedConfig }, { a: string }>
+// was: { readonly config: ResolvedConfig } & { a: string }
+// now: { config: ResolvedConfig; a: string }
+```
+
+Closes [#598](https://github.com/unional/type-plus/issues/598).

--- a/apps/website/src/content/docs/api/object.md
+++ b/apps/website/src/content/docs/api/object.md
@@ -178,12 +178,16 @@ type ObjectPlus.Merge<A extends AnyRecord, B extends AnyRecord>
 `SpreadRecord` is the type-level `{ ...a, ...b }` where `B` wins on conflicts.
 `LeftJoin` keeps the keys of `A` not in `B`, then adds all of `B`.
 `ObjectPlus.Merge` also handles `Record` inputs and required/optional joins.
+It models the spread faithfully, so the result is always writable: `readonly` on
+either side is dropped, and a get-only accessor - which is a `readonly` property -
+merges in as a plain writable data property.
 
 ```ts
 type R = SpreadRecord<{ a: 1; b: 2 }, { b: 3 }> // { a: 1 } & { b: 3 }
 
 import type { ObjectPlus } from 'type-plus'
 type M = ObjectPlus.Merge<{ a: 1 }, { b: 2 }> // { a: 1 } & { b: 2 }
+type G = ObjectPlus.Merge<{ get a(): 1 }, { b: 2 }> // { a: 1; b: 2 }
 ```
 
 ## `Split`

--- a/packages/type-plus/src/mix_types/merge.spec.ts
+++ b/packages/type-plus/src/mix_types/merge.spec.ts
@@ -83,12 +83,33 @@ describe('Merge', () => {
 
 		testType.canAssign<Merge<['a', 'b'], { concat: boolean }>, { concat: boolean }>(true)
 	})
+
+	it('spreads a get accessor into a writable property', () => {
+		// https://github.com/unional/type-plus/issues/598
+		type ResolvedConfig = { root: string }
+
+		const a = {
+			get config(): ResolvedConfig {
+				return { root: '/' }
+			},
+		}
+		const b = { a: 'a' }
+		const r = merge(a, b)
+		expect(r).toEqual({ config: { root: '/' }, a: 'a' })
+
+		// the spread produced a plain data property, so it is writable
+		r.config = { root: '/tmp' }
+		expect(r).toEqual({ config: { root: '/tmp' }, a: 'a' })
+
+		testType.equal<Merge<{ get config(): ResolvedConfig }, { a: string }>, { config: ResolvedConfig; a: string }>(true)
+	})
 })
 
 describe(`${merge.name}()`, () => {
 	it('', () => {
 		const r = merge({ a: 1 } as const, 2)
-		testType.equal<typeof r, { readonly a: 1 } & Number>(true)
+		// spreading copies values onto a fresh object, so `readonly` does not survive
+		testType.equal<typeof r, { a: 1 } & Number>(true)
 		expect(r).toEqual({ a: 1 })
 	})
 

--- a/packages/type-plus/src/mix_types/merge.ts
+++ b/packages/type-plus/src/mix_types/merge.ts
@@ -19,6 +19,16 @@ import type { Box } from './box.js'
  * which constraints `A` and `B` to be `Record`.
  *
  * This type does not have such restrictions, and tries to handle the other types accordingly.
+ *
+ * Like the spread it models, the result is always writable: `readonly` on
+ * either side is dropped, and a get-only accessor - which is a `readonly`
+ * property - merges in as a plain writable data property.
+ *
+ * @example
+ * ```ts
+ * type R = Merge<{ get config(): { root: string } }, { a: string }>
+ * // { config: { root: string }; a: string }
+ * ```
  */
 export type Merge<A, B> = Or<
 	IsNever<A>,

--- a/packages/type-plus/src/object/merge.spec.ts
+++ b/packages/type-plus/src/object/merge.spec.ts
@@ -21,6 +21,29 @@ it('merges disjoint types', () => {
 	testType.equal<ObjectPlus.Merge<{ a: 1 }, { b: 1 }>, { a: 1; b: 1 }>(true)
 })
 
+it('drops `readonly` because spreading copies values onto a fresh object', () => {
+	const a: { readonly a: 1 } = { a: 1 }
+	const b: { readonly b: 2 } = { b: 2 }
+
+	const r = { ...a, ...b }
+	r.a = 1
+	r.b = 2
+	expect(r).toEqual({ a: 1, b: 2 })
+
+	testType.equal<ObjectPlus.Merge<{ readonly a: 1 }, { b: 2 }>, { a: 1; b: 2 }>(true)
+	testType.equal<ObjectPlus.Merge<{ a: 1 }, { readonly b: 2 }>, { a: 1; b: 2 }>(true)
+	testType.equal<ObjectPlus.Merge<{ readonly a?: 1 }, { b: 2 }>, { a?: 1; b: 2 }>(true)
+})
+
+it('spreads a get accessor into a writable property', () => {
+	// https://github.com/unional/type-plus/issues/598
+	// a get-only accessor is a `readonly` property, so it follows the same rule
+	testType.equal<{ get a(): 1 }, { readonly a: 1 }>(true)
+
+	testType.equal<ObjectPlus.Merge<{ get a(): 1 }, { b: 2 }>, { a: 1; b: 2 }>(true)
+	testType.equal<ObjectPlus.Merge<{ a: 1 }, { get b(): 2 }>, { a: 1; b: 2 }>(true)
+})
+
 it('combines type with required and optional props', () => {
 	testType.equal<ObjectPlus.Merge<{ a: 1 }, { b?: 1 }>, { a: 1; b?: 1 }>(true)
 	testType.equal<ObjectPlus.Merge<{ a: 1 }, { b?: 1 | undefined }>, { a: 1; b?: 1 | undefined }>(true)

--- a/packages/type-plus/src/object/merge.ts
+++ b/packages/type-plus/src/object/merge.ts
@@ -20,6 +20,16 @@ import type { OptionalKeys } from './optional_key.js'
  *
  * It handles cases like A or B are `Record`,
  * joining between required and optional props, etc.
+ *
+ * Spreading copies property *values* onto a fresh object, so the result is
+ * always writable: `readonly` on either side is dropped, and because a
+ * get-only accessor is a `readonly` property, a getter merges in as a plain
+ * writable data property.
+ *
+ * @example
+ * ```ts
+ * type R = Merge<{ get a(): 1 }, { b: 2 }> // { a: 1; b: 2 }
+ * ```
  */
 export type Merge<
 	A extends AnyRecord,
@@ -40,7 +50,7 @@ export type Merge<
 			{
 				$then: never
 				$else: IsDisjoint<A, B> extends true
-					? A & B
+					? Spread<A> & Spread<B>
 					: [keyof A, keyof B] extends [infer KA extends KeyTypes, infer KB extends KeyTypes]
 						? IsLiteral<KA> extends true
 							? IsLiteral<KB> extends true
@@ -87,6 +97,20 @@ export type Merge<
 		>
 	}
 >
+
+/**
+ * Shallowly strips the `readonly` modifier from every property of `T`.
+ *
+ * `{ ...a }` copies the *values* of `a` onto a fresh object literal, so the
+ * result never carries `a`'s `readonly` modifiers. A get-only accessor is a
+ * `readonly` property (`{ get a(): 1 }` is `{ readonly a: 1 }`), so the same
+ * rule is what makes a getter spread into a plain writable data property.
+ *
+ * The mapping is homomorphic, so optionality, index signatures and
+ * distribution over unions are all preserved; only the modifier is dropped,
+ * and only at the top level - exactly matching the spread.
+ */
+type Spread<T> = { -readonly [K in keyof T]: T[K] }
 
 export namespace Merge {
 	export type JoinProps<A, B> = A extends NonComposableTypes ? B : B extends NonComposableTypes ? A : A & B


### PR DESCRIPTION
Closes #598.

## What goes wrong

`Merge` documents itself as the type-level `{ ...a, ...b }`. A spread copies property *values* onto a fresh object, so nothing it produces is `readonly` — TypeScript models this correctly for the real operator:

```ts
declare const a: { readonly x: number }
declare const g: { get c(): number }
const s = { ...a, ...g }
s.x = 1 // ok
s.c = 1 // ok
```

`ObjectPlus.Merge` has a fast path for disjoint inputs that returned `A & B` unchanged, which keeps `readonly` from either side. A get-only accessor **is** a `readonly` property — `{ get a(): 1 }` and `{ readonly a: 1 }` are the same type — so the reported repro produced a read-only `config`:

```ts
type R = Merge<{ get config(): ResolvedConfig }, { a: string }>
declare const r: R
r.config = { root: '/tmp' } // error TS2540: Cannot assign to 'config' because it is a read-only property
```

The non-disjoint paths were already correct: they rebuild the result through non-homomorphic mapped types (`{ [k in R]: A[k] }` over a filtered key union), which does not carry modifiers over.

This reproduces identically on TypeScript **5.4, 5.5, 5.6, 6.0 and 7** — it is not a version-specific accessor-typing limitation, just the fast path. It is fixable on the 5.4 floor.

## The fix

The disjoint branch now maps both sides through a homomorphic `-readonly` mapping:

```ts
type Spread<T> = { -readonly [K in keyof T]: T[K] }
```

Homomorphic mapping preserves optionality, index signatures and distribution over unions, and strips the modifier shallowly — exactly matching the spread.

## Behaviour change

One existing expectation moved, and it moved toward the truth:

```ts
const r = merge({ a: 1 } as const, 2)
// was: { readonly a: 1 } & Number
// now: { a: 1 } & Number
```

`{ ...{ a: 1 } as const, ...2 }` is a fresh writable object at runtime, so the new type is the correct one.

## Verification

- `pnpm verify` green
- `pnpm --filter type-plus test:type` green on all five TS versions (5.4, 5.5, 5.6, 6.0, 7)
- New specs in `src/object/merge.spec.ts` (readonly on either side, optional + readonly, getter on either side) and a repro-shaped regression test in `src/mix_types/merge.spec.ts` that also asserts the runtime spread is writable
- TSDoc on both `Merge` types documents the rule, with `@example`s pinned by the new `testType.equal` checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)