### PR TITLE
fix(type-plus): classify primitive-and-record intersections by the primitive

### DIFF
--- a/.changeset/pink-hoops-classify.md
+++ b/.changeset/pink-hoops-classify.md
@@ -1,0 +1,28 @@
+---
+'type-plus': patch
+---
+
+Classify an intersection of a primitive with a record by its primitive constituent, fixing #429.
+
+`IsStringLiteral`, `IsTemplateLiteral`, and their negations read the kind of a string type through
+`` `${T}` ``, and `IsNegative`, `IsPositive`, `IsNotNegative` and `IsNotPositive` read a sign off the
+same template. TypeScript 5.1 stopped reducing an intersection inside a template
+([microsoft/TypeScript#57918](https://github.com/microsoft/TypeScript/issues/57918), still open), so
+`` `${'abc' & { a: 1 }}` `` stayed unresolved and every one of those types answered as though the
+string or number were not there:
+
+```ts
+type R = IsStringLiteral<'abc' & { a: 1 }, { exact: true }> // was false, now true
+type R = IsTemplateLiteral<'abc' & { a: 1 }> // was true, now false
+type R = IsNegative<-1 & { a: 1 }> // was false, now true
+```
+
+The intersected members are now peeled off before the template is built, using TypeScript's
+inference to an intersection target (`T extends infer U & O`) rather than the template reduction TS
+withdrew. Both spellings of the members are handled — one record holding several
+(`'abc' & { a: 1, b: 2 }`) and several records (`'abc' & { a: 1 } & { b: 2 }`).
+
+Two shapes remain unreduced, both for the same upstream reason: an intersected index signature
+(`'abc' & Record<number, unknown>`), whose key is one `String` already declares, and an intersection
+nested inside a string manipulation type (`Uppercase<'' & { a: 1 }>`), which never surfaces as a
+constituent of the outer type.

--- a/packages/type-plus/src/$type/utils/_bare_intersection.ts
+++ b/packages/type-plus/src/$type/utils/_bare_intersection.ts
@@ -1,0 +1,72 @@
+import type { UnionToIntersection } from '../../union/union_to_intersection.js'
+
+/**
+ * Reduce an intersection between a primitive type and one or more object types
+ * down to its bare primitive constituent.
+ *
+ * `Base` is the wrapper interface the primitive already carries — `String` for a
+ * string type, `Number` for a number type — and its keys are what the peel
+ * treats as belonging to the primitive rather than to the intersected objects.
+ *
+ * ```ts
+ * type R = _BareIntersection<'abc' & { a: 1 }, String> // 'abc'
+ * type R = _BareIntersection<`${number}` & { a: 1 }, String> // `${number}`
+ * type R = _BareIntersection<string & { a: 1 }, String> // string
+ * type R = _BareIntersection<'abc', String> // 'abc'
+ * ```
+ *
+ * TypeScript does not reduce `` `${'abc' & { a: 1 }}` `` to `'abc'`
+ * (https://github.com/microsoft/TypeScript/issues/57918), so every template
+ * literal operation — matching, inference, and the mapped key trick
+ * `_StringType` uses — is blind to the primitive inside such an intersection.
+ * Peeling the object members off first restores those operations.
+ *
+ * The peel relies on TypeScript's inference to an intersection target:
+ * `T extends infer U & O` binds `U` to the constituents of `T` that `O` did not
+ * account for. `O` has to line up with how `T` spells its object members, so the
+ * peel is attempted twice — once with the members collapsed into a single object
+ * (matching `'abc' & { a: 1, b: 2 }`), once with one object per member (matching
+ * `'abc' & { a: 1 } & { b: 2 }`).
+ *
+ * Two shapes stay unreduced, and `T` is then returned as-is:
+ *
+ * - an intersected index signature (`'abc' & Record<number, unknown>`), whose key
+ *   is one `Base` already declares, leaving nothing for the peel to match on.
+ * - an intersection nested inside a string manipulation type
+ *   (`Uppercase<'' & { a: 1 }>`), which never surfaces as a constituent of `T`.
+ */
+export type _BareIntersection<T, Base> =
+	_BareIntersection._Peel<T, _BareIntersection._Collapsed<T, Base>> extends infer U
+		? _BareIntersection._IsBare<U, Base> extends true
+			? U
+			: _BareIntersection._Peel<T, _BareIntersection._PerMember<T, Base>>
+		: never
+
+export namespace _BareIntersection {
+	/**
+	 * The keys `T` carries beyond the ones `Base` already declares.
+	 */
+	export type _Keys<T, Base> = Exclude<keyof T, keyof Base>
+
+	/**
+	 * The extra members of `T` as one object type.
+	 */
+	export type _Collapsed<T, Base> = { [K in _Keys<T, Base>]: T[K] }
+
+	/**
+	 * The extra members of `T` as an intersection of single-member object types.
+	 */
+	export type _PerMember<T, Base> = UnionToIntersection<
+		_Keys<T, Base> extends infer K ? (K extends PropertyKey ? { [P in K]: T[K & keyof T] } : never) : never
+	>
+
+	/**
+	 * Infer away the constituents of `T` covered by `O`, or keep `T` when `O` does not match.
+	 */
+	export type _Peel<T, O> = T extends infer U & O ? U : T
+
+	/**
+	 * Whether `T` is a primitive type with no object members intersected into it.
+	 */
+	export type _IsBare<T, Base> = [_Keys<T, Base>] extends [never] ? true : false
+}

--- a/packages/type-plus/src/$type/utils/_bare_intersection.unit.ts
+++ b/packages/type-plus/src/$type/utils/_bare_intersection.unit.ts
@@ -1,0 +1,35 @@
+import { it } from 'vitest'
+import { testType } from '../../index.js'
+import type { _BareIntersection } from './_bare_intersection.js'
+
+it('leaves a bare type alone', () => {
+	testType.equal<_BareIntersection<string, String>, string>(true)
+	testType.equal<_BareIntersection<'', String>, ''>(true)
+	testType.equal<_BareIntersection<'abc', String>, 'abc'>(true)
+	testType.equal<_BareIntersection<`${number}`, String>, `${number}`>(true)
+	testType.equal<_BareIntersection<Uppercase<`${number}`>, String>, Uppercase<`${number}`>>(true)
+	testType.equal<_BareIntersection<-1, Number>, -1>(true)
+})
+
+it('peels a single intersected record', () => {
+	testType.equal<_BareIntersection<'abc' & { a: 1 }, String>, 'abc'>(true)
+	testType.equal<_BareIntersection<`${number}` & { a: 1 }, String>, `${number}`>(true)
+	testType.equal<_BareIntersection<string & { a: 1 }, String>, string>(true)
+	testType.equal<_BareIntersection<-1 & { a: 1 }, Number>, -1>(true)
+})
+
+it('peels a record holding multiple members', () => {
+	testType.equal<_BareIntersection<'abc' & { a: 1; b: 2 }, String>, 'abc'>(true)
+})
+
+it('peels multiple intersected records', () => {
+	testType.equal<_BareIntersection<'abc' & { a: 1 } & { b: 2 }, String>, 'abc'>(true)
+})
+
+it('does not peel an intersected index signature', () => {
+	testType.equal<_BareIntersection<'abc' & Record<number, unknown>, String>, 'abc' & Record<number, unknown>>(true)
+})
+
+it('does not peel an intersection nested inside a string manipulation type', () => {
+	testType.equal<_BareIntersection<Uppercase<'' & { a: 1 }>, String>, Uppercase<'' & { a: 1 }>>(true)
+})

--- a/packages/type-plus/src/numeric/_numeric_sign.ts
+++ b/packages/type-plus/src/numeric/_numeric_sign.ts
@@ -1,0 +1,17 @@
+import type { _BareIntersection } from '../$type/utils/_bare_intersection.js'
+
+/**
+ * Whether the numeric type `T` carries a minus sign.
+ *
+ * The sign is read off `` `${T}` ``, which TypeScript leaves unreduced when `T`
+ * is an intersection such as `-1 & { a: 1 }`
+ * (https://github.com/microsoft/TypeScript/issues/57918), so `T` is peeled down
+ * to its bare numeric constituent first.
+ * See {@link _BareIntersection} for the shapes that peel and the ones that do not.
+ */
+export type _IsNegativeSign<T> =
+	_BareIntersection<T, Number & BigInt> extends infer B extends number | bigint
+		? `${B}` extends `-${string}`
+			? true
+			: false
+		: false

--- a/packages/type-plus/src/numeric/is_negative.spec.ts
+++ b/packages/type-plus/src/numeric/is_negative.spec.ts
@@ -68,10 +68,9 @@ it('returns boolean if T is union of mixing positive and negative value', () => 
 	testType.strictBoolean<IsNegative<1 | -1>>(true)
 })
 
-// FIXME: https://github.com/microsoft/TypeScript/issues/57918
-it.skip('returns true if T is an intersection of negative numbers', () => {
-	// testType.true<IsNegative<-1 & { a: 1 }>>(true)
-	// testType.true<IsNegative<-1n & { a: 1 }>>(true)
+it('returns true if T is an intersection of negative numbers', () => {
+	testType.true<IsNegative<-1 & { a: 1 }>>(true)
+	testType.true<IsNegative<-1n & { a: 1 }>>(true)
 })
 
 it('returns false if T is intersection of non-negative numbers', () => {

--- a/packages/type-plus/src/numeric/is_negative.ts
+++ b/packages/type-plus/src/numeric/is_negative.ts
@@ -9,6 +9,7 @@ import type { $Unknown } from '../$type/special/$unknown.js'
 import type { $Void } from '../$type/special/$void.js'
 import type { IsBigint } from '../bigint/is_bigint.js'
 import type { IsNumber } from '../number/is_number.js'
+import type { _IsNegativeSign } from './_numeric_sign.js'
 
 /**
  * 🎭 *predicate*
@@ -40,6 +41,14 @@ import type { IsNumber } from '../number/is_number.js'
  * type R = IsNegative<unknown> // false
  * type R = IsNegative<never> // false
  * type R = IsNegative<void> // false
+ * ```
+ *
+ * An intersection with a record is classified by its numeric constituent.
+ *
+ * @example
+ * ```ts
+ * type R = IsNegative<-1 & { a: 1 }> // true
+ * type R = IsNegative<1 & { a: 1 }> // false
  * ```
  *
  * 🔢 *customize*
@@ -97,7 +106,7 @@ export namespace IsNegative {
 	export type $Branch<$O extends $Options = {}> = $Selection.Branch<$O>
 
 	export type _Negative<T, U extends number | bigint, $O extends IsNegative.$Options> = T extends U & infer R
-		? `${T}` extends `-${string}`
+		? _IsNegativeSign<T> extends true
 			? $ResolveBranch<$O, [$Then], T>
 			: U extends T
 				? $ResolveBranch<$O, [$Then], T> | $ResolveBranch<$O, [$Else]>

--- a/packages/type-plus/src/numeric/is_not_negative.spec.ts
+++ b/packages/type-plus/src/numeric/is_not_negative.spec.ts
@@ -72,10 +72,9 @@ it('returns true if T is intersection of positive number', () => {
 	testType.equal<IsNotNegative<1n & { a: 1 }>, true>(true)
 })
 
-// FIXME: https://github.com/microsoft/TypeScript/issues/57918
-it.skip('returns false if T is intersection of negative number', () => {
-	// testType.equal<IsNotNegative<-1 & { a: 1 }>, false>(true)
-	// testType.equal<IsNotNegative<-1n & { a: 1 }>, false>(true)
+it('returns false if T is intersection of negative number', () => {
+	testType.equal<IsNotNegative<-1 & { a: 1 }>, false>(true)
+	testType.equal<IsNotNegative<-1n & { a: 1 }>, false>(true)
 })
 
 it('returns true if T is intersection of non-negative number', () => {

--- a/packages/type-plus/src/numeric/is_not_negative.ts
+++ b/packages/type-plus/src/numeric/is_not_negative.ts
@@ -9,6 +9,7 @@ import type { $Unknown } from '../$type/special/$unknown.js'
 import type { $Void } from '../$type/special/$void.js'
 import type { IsBigint } from '../bigint/is_bigint.js'
 import type { IsNumber } from '../number/is_number.js'
+import type { _IsNegativeSign } from './_numeric_sign.js'
 
 /**
  * 🎭 *predicate*
@@ -40,6 +41,14 @@ import type { IsNumber } from '../number/is_number.js'
  * type R = IsNotNegative<unknown> // true
  * type R = IsNotNegative<never> // true
  * type R = IsNotNegative<void> // true
+ * ```
+ *
+ * An intersection with a record is classified by its numeric constituent.
+ *
+ * @example
+ * ```ts
+ * type R = IsNotNegative<1 & { a: 1 }> // true
+ * type R = IsNotNegative<-1 & { a: 1 }> // false
  * ```
  *
  * 🔢 *customize*
@@ -101,7 +110,7 @@ export namespace IsNotNegative {
 		$InputOptions<$Any | $Unknown | $Never | $Void>
 	export type $Branch<$O extends $Options = {}> = $Selection.Branch<$O>
 	export type _Negative<T, U extends number | bigint, $O extends IsNotNegative.$Options> = T extends U
-		? `${T}` extends `-${string}`
+		? _IsNegativeSign<T> extends true
 			? $ResolveBranch<$O, [$Else]>
 			: U extends T
 				? $ResolveBranch<$O, [$Then], T> | $ResolveBranch<$O, [$Else]>

--- a/packages/type-plus/src/numeric/is_not_positive.spec.ts
+++ b/packages/type-plus/src/numeric/is_not_positive.spec.ts
@@ -74,10 +74,9 @@ it('returns false if T is intersection of 0 or positive number', () => {
 	testType.false<IsNotPositive<0n & { a: 1 }>>(true)
 })
 
-// FIXME: https://github.com/microsoft/TypeScript/issues/57918
-it.skip('returns true if T is intersection of non-positive number', () => {
-	// testType.true<IsNotPositive<-1 & { a: 1 }>>(true)
-	// testType.true<IsNotPositive<-1n & { a: 1 }>>(true)
+it('returns true if T is intersection of non-positive number', () => {
+	testType.true<IsNotPositive<-1 & { a: 1 }>>(true)
+	testType.true<IsNotPositive<-1n & { a: 1 }>>(true)
 })
 
 it('distributes over union type', () => {

--- a/packages/type-plus/src/numeric/is_not_positive.ts
+++ b/packages/type-plus/src/numeric/is_not_positive.ts
@@ -9,6 +9,7 @@ import type { $Unknown } from '../$type/special/$unknown.js'
 import type { $Void } from '../$type/special/$void.js'
 import type { IsBigint } from '../bigint/is_bigint.js'
 import type { IsNumber } from '../number/is_number.js'
+import type { _IsNegativeSign } from './_numeric_sign.js'
 
 /**
  * 🎭 *predicate*
@@ -41,6 +42,14 @@ import type { IsNumber } from '../number/is_number.js'
  * type R = IsNotPositive<unknown> // true
  * type R = IsNotPositive<never> // true
  * type R = IsNotPositive<void> // true
+ * ```
+ *
+ * An intersection with a record is classified by its numeric constituent.
+ *
+ * @example
+ * ```ts
+ * type R = IsNotPositive<-1 & { a: 1 }> // true
+ * type R = IsNotPositive<1 & { a: 1 }> // false
  * ```
  *
  * 🔢 *customize*
@@ -100,7 +109,7 @@ export namespace IsNotPositive {
 	export type $Branch<$O extends $Options = {}> = $Selection.Branch<$O>
 
 	export type _Negative<T, U extends number | bigint, $O extends IsNotPositive.$Options> = T extends U
-		? `${T}` extends `-${string}`
+		? _IsNegativeSign<T> extends true
 			? $ResolveBranch<$O, [$Then], T>
 			: U extends T
 				? $ResolveBranch<$O, [$Then], T> | $ResolveBranch<$O, [$Else]>

--- a/packages/type-plus/src/numeric/is_positive.spec.ts
+++ b/packages/type-plus/src/numeric/is_positive.spec.ts
@@ -73,12 +73,8 @@ it('returns true if T is intersection of positive number', () => {
 	testType.true<IsPositive<1n & { a: 1 }>>(true)
 })
 
-// https://github.com/microsoft/TypeScript/issues/54648#issuecomment-1990057710
-// https://github.com/microsoft/TypeScript/issues/57776
-it.skip('returns false if T is intersection of non-positive number', () => {
-	// @ts-expect-error
+it('returns false if T is intersection of non-positive number', () => {
 	testType.false<IsPositive<-1 & { a: 1 }>>(true)
-	// @ts-expect-error
 	testType.false<IsPositive<-1n & { a: 1 }>>(true)
 })
 

--- a/packages/type-plus/src/numeric/is_positive.ts
+++ b/packages/type-plus/src/numeric/is_positive.ts
@@ -9,6 +9,7 @@ import type { $Unknown } from '../$type/special/$unknown.js'
 import type { $Void } from '../$type/special/$void.js'
 import type { IsBigint } from '../bigint/is_bigint.js'
 import type { IsNumber } from '../number/is_number.js'
+import type { _IsNegativeSign } from './_numeric_sign.js'
 
 /**
  * 🎭 *predicate*
@@ -39,6 +40,14 @@ import type { IsNumber } from '../number/is_number.js'
  * type R = IsPositive<unknown> // false
  * type R = IsPositive<never> // false
  * type R = IsPositive<void> // false
+ * ```
+ *
+ * An intersection with a record is classified by its numeric constituent.
+ *
+ * @example
+ * ```ts
+ * type R = IsPositive<1 & { a: 1 }> // true
+ * type R = IsPositive<-1 & { a: 1 }> // false
  * ```
  *
  * 🔢 *customize*
@@ -95,7 +104,7 @@ export namespace IsPositive {
 	export type $Branch<$O extends $Options = {}> = $Selection.Branch<$O>
 
 	export type _Positive<T, U extends number | bigint, $O extends IsPositive.$Options> = T extends U & infer R
-		? `${T}` extends `-${string}`
+		? _IsNegativeSign<T> extends true
 			? $ResolveBranch<$O, [$Else]>
 			: U extends T
 				? $ResolveBranch<$O, [$Then], T> | $ResolveBranch<$O, [$Else]>

--- a/packages/type-plus/src/string/_string_type.ts
+++ b/packages/type-plus/src/string/_string_type.ts
@@ -1,12 +1,22 @@
+import type { _BareIntersection } from '../$type/utils/_bare_intersection.js'
 import type { $ExtractManipulatedString } from './$extract_manipulated_string.js'
 
+/**
+ * Classify `T` as `'string'`, `'stringLiteral'`, or `'templateLiteral'`.
+ *
+ * `T` is peeled down to its bare string constituent first, so an intersection
+ * such as `'abc' & { a: 1 }` classifies the same as `'abc'`.
+ * See {@link _BareIntersection} for the shapes that peel and the ones that do not.
+ */
 export type _StringType<T extends string> =
-	$ExtractManipulatedString<T> extends infer K
-		? K extends string & infer U
-			? [K, U] extends [U, K]
-				? {} extends { [P in `${K}`]: unknown }
-					? 'templateLiteral'
-					: 'stringLiteral'
-				: 'string'
+	_BareIntersection<T, String> extends infer B extends string
+		? $ExtractManipulatedString<B> extends infer K
+			? K extends string & infer U
+				? [K, U] extends [U, K]
+					? {} extends { [P in `${K}`]: unknown }
+						? 'templateLiteral'
+						: 'stringLiteral'
+					: 'string'
+				: never
 			: never
 		: never

--- a/packages/type-plus/src/string/_string_type.unit.ts
+++ b/packages/type-plus/src/string/_string_type.unit.ts
@@ -26,14 +26,18 @@ it('detects string intersects with record as `string`', () => {
 	testType.equal<_StringType<string & Record<number, unknown>>, 'string'>(true)
 })
 
-// FIXME: https://github.com/microsoft/TypeScript/issues/57918
-it.skip('detects string literal intersects with record as `stringLiteral`', () => {
-	// testType.equal<_StringType<'' & { a: 1 }>, 'stringLiteral'>(true)
-	// testType.equal<_StringType<'a' & { a: 1 }>, 'stringLiteral'>(true)
-	// testType.equal<_StringType<'abc' & { a: 1 }>, 'stringLiteral'>(true)
-	// testType.equal<_StringType<'123' & { a: 1 }>, 'stringLiteral'>(true)
-	// testType.equal<_StringType<'true' & { a: 1 }>, 'stringLiteral'>(true)
-	// testType.equal<_StringType<`a${boolean}b` & { a: 1 }>, 'stringLiteral'>(true)
+it('detects string literal intersects with record as `stringLiteral`', () => {
+	testType.equal<_StringType<'' & { a: 1 }>, 'stringLiteral'>(true)
+	testType.equal<_StringType<'a' & { a: 1 }>, 'stringLiteral'>(true)
+	testType.equal<_StringType<'abc' & { a: 1 }>, 'stringLiteral'>(true)
+	testType.equal<_StringType<'123' & { a: 1 }>, 'stringLiteral'>(true)
+	testType.equal<_StringType<'true' & { a: 1 }>, 'stringLiteral'>(true)
+	testType.equal<_StringType<`a${boolean}b` & { a: 1 }>, 'stringLiteral'>(true)
+})
+
+it('detects string literal intersects with a multi-member record as `stringLiteral`', () => {
+	testType.equal<_StringType<'abc' & { a: 1; b: 2 }>, 'stringLiteral'>(true)
+	testType.equal<_StringType<'abc' & { a: 1 } & { b: 2 }>, 'stringLiteral'>(true)
 })
 
 it('detects template literal intersects with record as `templateLiteral`', () => {

--- a/packages/type-plus/src/string/is_not_string_literal.spec.ts
+++ b/packages/type-plus/src/string/is_not_string_literal.spec.ts
@@ -317,9 +317,9 @@ describe('enable exact', () => {
 		testType.true<IsNotStringLiteral<`a-${number}` & { a: 1 }, { exact: true }>>(true)
 	})
 
-	it.skip('returns false for intersection type of string literal and record', () => {
-		// FIXME: https://github.com/microsoft/TypeScript/issues/57776
-		// testType.false<IsNotStringLiteral<'abc' & { a: 1 }, { exact: true }>>(true)
+	it('returns false for intersection type of string literal and record', () => {
+		testType.false<IsNotStringLiteral<'' & { a: 1 }, { exact: true }>>(true)
+		testType.false<IsNotStringLiteral<'abc' & { a: 1 }, { exact: true }>>(true)
 	})
 
 	it('works as filter', () => {
@@ -450,9 +450,9 @@ describe('enable exact', () => {
 			testType.true<IsNotStringLiteral<`a-${number}` & { a: 1 }, { distributive: false; exact: true }>>(true)
 		})
 
-		it.skip('returns false for intersection type of string literal and record', () => {
-			// FIXME: https://github.com/microsoft/TypeScript/issues/57776
-			// testType.false<IsNotStringLiteral<'abc' & { a: 1 }, { distributive: false, exact: true }>>(true)
+		it('returns false for intersection type of string literal and record', () => {
+			testType.false<IsNotStringLiteral<'' & { a: 1 }, { distributive: false; exact: true }>>(true)
+			testType.false<IsNotStringLiteral<'abc' & { a: 1 }, { distributive: false; exact: true }>>(true)
 		})
 	})
 })

--- a/packages/type-plus/src/string/is_not_string_literal.ts
+++ b/packages/type-plus/src/string/is_not_string_literal.ts
@@ -29,6 +29,15 @@ import type { _StringType } from './_string_type.js'
  * type R = IsNotStringLiteral<'a' | boolean> // boolean
  * ```
  *
+ * An intersection with a record is classified by its string constituent.
+ *
+ * @example
+ * ```ts
+ * type R = IsNotStringLiteral<'abc' & { a: 1 }> // false
+ * type R = IsNotStringLiteral<'abc' & { a: 1 }, { exact: true }> // false
+ * type R = IsNotStringLiteral<string & { a: 1 }> // true
+ * ```
+ *
  * 🔢 *customize*
  *
  * Filter to ensure `T` is not a string literal(s), otherwise returns `never`.

--- a/packages/type-plus/src/string/is_not_template_literal.spec.ts
+++ b/packages/type-plus/src/string/is_not_template_literal.spec.ts
@@ -103,11 +103,8 @@ it('returns true for intersection type of non template literal and record', () =
 	testType.true<IsNotTemplateLiteral<123 & { a: 1 }>>(true)
 	testType.true<IsNotTemplateLiteral<string & { a: 1 }>>(true)
 
-	// @ts-expect-error https://github.com/microsoft/TypeScript/issues/57918
 	testType.true<IsNotTemplateLiteral<'' & { a: 1 }>>(true)
-	// @ts-expect-error https://github.com/microsoft/TypeScript/issues/57918
 	testType.true<IsNotTemplateLiteral<'abc' & { a: 1 }>>(true)
-	// @ts-expect-error https://github.com/microsoft/TypeScript/issues/57918
 	testType.true<IsNotTemplateLiteral<Uppercase<``> & { a: 1 }>>(true)
 })
 
@@ -203,11 +200,8 @@ describe('disable distribution', () => {
 		testType.true<IsNotTemplateLiteral<123 & { a: 1 }, { distributive: false }>>(true)
 		testType.true<IsNotTemplateLiteral<string & { a: 1 }, { distributive: false }>>(true)
 
-		// @ts-expect-error https://github.com/microsoft/TypeScript/issues/57918
 		testType.true<IsNotTemplateLiteral<'' & { a: 1 }, { distributive: false }>>(true)
-		// @ts-expect-error https://github.com/microsoft/TypeScript/issues/57918
 		testType.true<IsNotTemplateLiteral<'abc' & { a: 1 }, { distributive: false }>>(true)
-		// @ts-expect-error https://github.com/microsoft/TypeScript/issues/57918
 		testType.true<IsNotTemplateLiteral<Uppercase<``> & { a: 1 }, { distributive: false }>>(true)
 	})
 

--- a/packages/type-plus/src/string/is_not_template_literal.ts
+++ b/packages/type-plus/src/string/is_not_template_literal.ts
@@ -28,6 +28,15 @@ import type { _StringType } from './_string_type.js'
  * type R = IsNotTemplateLiteral<`${number}` | boolean> // boolean
  * ```
  *
+ * An intersection with a record is classified by its string constituent.
+ *
+ * @example
+ * ```ts
+ * type R = IsNotTemplateLiteral<`a-${number}` & { a: 1 }> // false
+ * type R = IsNotTemplateLiteral<'abc' & { a: 1 }> // true
+ * type R = IsNotTemplateLiteral<string & { a: 1 }> // true
+ * ```
+ *
  * 🔢 *customize*
  *
  * Filter to ensure `T` is not a template literal(s), otherwise returns `never`.

--- a/packages/type-plus/src/string/is_string_literal.spec.ts
+++ b/packages/type-plus/src/string/is_string_literal.spec.ts
@@ -649,9 +649,11 @@ describe('enable exact', () => {
 		testType.false<IsStringLiteral<`a-${number}` & { a: 1 }, { exact: true }>>(true)
 	})
 
-	it.skip('returns true for intersection type of string literal and record', () => {
-		// FIXME: https://github.com/microsoft/TypeScript/issues/57776
-		// testType.true<IsStringLiteral<'abc' & { a: 1 }, { exact: true }>>(true)
+	it('returns true for intersection type of string literal and record', () => {
+		testType.true<IsStringLiteral<'' & { a: 1 }, { exact: true }>>(true)
+		testType.true<IsStringLiteral<'abc' & { a: 1 }, { exact: true }>>(true)
+		testType.true<IsStringLiteral<'abc' & { a: 1 } & { b: 2 }, { exact: true }>>(true)
+		testType.true<IsStringLiteral<'abc' & { a: 1; b: 2 }, { exact: true }>>(true)
 	})
 
 	it('works as filter', () => {
@@ -802,9 +804,9 @@ describe('enable exact', () => {
 			testType.equal<IsStringLiteral<'a' | number, { distributive: false; exact: true }>, false>(true)
 		})
 
-		it.skip('works with intersection type', () => {
-			// FIXME: https://github.com/microsoft/TypeScript/issues/57776
-			// testType.true<IsStringLiteral<'' & { a: 1 }, { distributive: false, exact: true }>>(true)
+		it('works with intersection type', () => {
+			testType.true<IsStringLiteral<'' & { a: 1 }, { distributive: false; exact: true }>>(true)
+			testType.true<IsStringLiteral<'abc' & { a: 1 }, { distributive: false; exact: true }>>(true)
 			testType.false<IsStringLiteral<1 & { a: 1 }, { distributive: false; exact: true }>>(true)
 			testType.false<IsStringLiteral<string & { a: 1 }, { distributive: false; exact: true }>>(true)
 			testType.false<IsStringLiteral<`${number}` & { a: 1 }, { distributive: false; exact: true }>>(true)

--- a/packages/type-plus/src/string/is_string_literal.ts
+++ b/packages/type-plus/src/string/is_string_literal.ts
@@ -29,6 +29,15 @@ import type { _StringType } from './_string_type.js'
  * type R = IsStringLiteral<'a' | boolean> // boolean
  * ```
  *
+ * An intersection with a record is classified by its string constituent.
+ *
+ * @example
+ * ```ts
+ * type R = IsStringLiteral<'abc' & { a: 1 }> // true
+ * type R = IsStringLiteral<'abc' & { a: 1 }, { exact: true }> // true
+ * type R = IsStringLiteral<string & { a: 1 }> // false
+ * ```
+ *
  * 🔢 *customize*
  *
  * Filter to ensure `T` is a string literal(s), otherwise returns `never`.

--- a/packages/type-plus/src/string/is_template_literal.spec.ts
+++ b/packages/type-plus/src/string/is_template_literal.spec.ts
@@ -213,11 +213,8 @@ it('returns false for intersection type of non template literal and record', () 
 	testType.false<IsTemplateLiteral<123 & { a: 1 }>>(true)
 	testType.false<IsTemplateLiteral<string & { a: 1 }>>(true)
 
-	// @ts-expect-error https://github.com/microsoft/TypeScript/issues/57918
 	testType.false<IsTemplateLiteral<'' & { a: 1 }>>(true)
-	// @ts-expect-error https://github.com/microsoft/TypeScript/issues/57918
 	testType.false<IsTemplateLiteral<'abc' & { a: 1 }>>(true)
-	// @ts-expect-error https://github.com/microsoft/TypeScript/issues/57918
 	testType.false<IsTemplateLiteral<Uppercase<``> & { a: 1 }>>(true)
 })
 
@@ -448,11 +445,8 @@ describe('disable distribution', () => {
 		testType.false<IsTemplateLiteral<123 & { a: 1 }, { distributive: false }>>(true)
 		testType.false<IsTemplateLiteral<string & { a: 1 }, { distributive: false }>>(true)
 
-		// @ts-expect-error https://github.com/microsoft/TypeScript/issues/57918
 		testType.false<IsTemplateLiteral<'' & { a: 1 }, { distributive: false }>>(true)
-		// @ts-expect-error https://github.com/microsoft/TypeScript/issues/57918
 		testType.false<IsTemplateLiteral<'abc' & { a: 1 }, { distributive: false }>>(true)
-		// @ts-expect-error https://github.com/microsoft/TypeScript/issues/57918
 		testType.false<IsTemplateLiteral<Uppercase<``> & { a: 1 }, { distributive: false }>>(true)
 	})
 

--- a/packages/type-plus/src/string/is_template_literal.ts
+++ b/packages/type-plus/src/string/is_template_literal.ts
@@ -30,6 +30,15 @@ import type { _StringType } from './_string_type.js'
  * type R = IsTemplateLiteral<`${number}` | boolean> // boolean
  * ```
  *
+ * An intersection with a record is classified by its string constituent.
+ *
+ * @example
+ * ```ts
+ * type R = IsTemplateLiteral<`a-${number}` & { a: 1 }> // true
+ * type R = IsTemplateLiteral<'abc' & { a: 1 }> // false
+ * type R = IsTemplateLiteral<string & { a: 1 }> // false
+ * ```
+ *
  * 🔢 *customize*
  *
  * Filter to ensure `T` is a template literal(s), otherwise returns `never`.


### PR DESCRIPTION
Closes #429.

## What #429 turned out to be

The batch of TS2345 failures in the issue is one bug with one cause. `IsStringLiteral`, `IsTemplateLiteral` and their negations read a string's kind through `` `${T}` ``, and `IsNegative`, `IsPositive`, `IsNotNegative`, `IsNotPositive` read a sign off the same template. TypeScript 5.1 stopped reducing an intersection inside a template — [microsoft/TypeScript#57918](https://github.com/microsoft/TypeScript/issues/57918), which you filed and which is still open, labelled *Suggestion / Awaiting More Feedback*. `` `${'abc' & { a: 1 }}` `` stays unresolved, so every one of those types answers as though the primitive were not there.

It still reproduces on all five supported versions. Verified on TypeScript 5.4.5, 5.5.4, 5.6.3, 6.0.3 and 7 — identical behavior on each, no upstream change to lean on.

## It is fixable on the 5.4 floor

Not by getting the template to reduce — nothing recovers the string out of `'abc' & { a: 1 }` through template matching, template inference, `Extract`, or a mapped type; each returns `never` or the unreduced intersection on every supported version. But *inference to an intersection target* does subtract: `T extends infer U & { a: 1 }` binds `U` to `'abc'`. The object side can be reconstructed from `T` itself, so the subtraction needs no advance knowledge of what was intersected in.

`_BareIntersection<T, Base>` does that. `Base` is the wrapper interface whose keys belong to the primitive (`String` for `_StringType`, `Number & BigInt` for the new `_IsNegativeSign`); everything else in `keyof T` came from the intersected records and gets peeled off before the template is built. The peel runs twice, because `O` has to match how `T` spells its members: once with them collapsed into one object (`'abc' & { a: 1, b: 2 }`), once with one object per member (`'abc' & { a: 1 } & { b: 2 }`). The two are complementary and together cover both spellings.

Behavior identical on 5.4, 5.5, 5.6, 6.0 and 7.

```ts
type R = IsStringLiteral<'abc' & { a: 1 }, { exact: true }> // was false, now true
type R = IsTemplateLiteral<'abc' & { a: 1 }> // was true, now false
type R = IsNegative<-1 & { a: 1 }> // was false, now true
```

## What still does not reduce

Two shapes, both still #57918, now documented on `_BareIntersection` and pinned by unit tests that assert the unreduced result rather than leaving it unstated:

- an intersected index signature (`'abc' & Record<number, unknown>`) — its key is one `Base` already declares, so nothing is left to match on;
- an intersection nested inside a string manipulation type (`Uppercase<'' & { a: 1 }>`) — it never surfaces as a constituent of the outer type. TypeScript 6.0 *can* infer through the resulting single-placeholder template where 5.4 through 5.6 cannot, so a fix here would behave differently across the supported range; left alone deliberately.

## Specs

Six `@ts-expect-error` directives and six `it.skip` blocks recorded the wrong answers. They now assert the right ones:

- `is_template_literal.spec.ts`, `is_not_template_literal.spec.ts` — the `@ts-expect-error` markers on the intersection blocks are gone.
- `is_string_literal.spec.ts`, `is_not_string_literal.spec.ts` — the `{ exact: true }` intersection blocks are un-skipped, and cover multi-member and multi-record spellings.
- `is_negative.spec.ts`, `is_positive.spec.ts`, `is_not_negative.spec.ts`, `is_not_positive.spec.ts` — the four skipped sign blocks are un-skipped.
- `_string_type.unit.ts` — the skipped `stringLiteral` block is un-skipped and extended.
- `_bare_intersection.unit.ts` — new, covering both peel tiers and both residual limitations.

Every new `@example` line is pinned by an assertion in the spec for the symbol it documents.

`pnpm verify` is green, and `pnpm --filter type-plus test:type` passes on 5.4, 5.5, 5.6, 6.0 and 7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)