### PR TITLE
fix(type-plus): answer special types with TypeScript's assignability relation

### DIFF
--- a/.changeset/assignability-specials-349.md
+++ b/.changeset/assignability-specials-349.md
@@ -1,0 +1,48 @@
+---
+'type-plus': major
+---
+
+Answer `any`, `unknown`, `never` and `void` with TypeScript's own assignability relation in
+`CanAssign`, `IsAssign`, `StrictCanAssign`, `Assignable` and `NotAssignable`.
+
+`CanAssign<A, B>` was a bare `A extends B` behind a `boolean` guard. `extends` is not
+assignability: it gets all three special types wrong, and `boolean extends A` swallowed `any`
+and `unknown` on the way past. The rule now applied everywhere is the compiler's:
+
+- `any` is assignable to every type except `never`, and every type is assignable to `any`.
+  The relation is **symmetric** for `any`, exactly as it is in TypeScript — both
+  `const b: number = a` and `const c: any = n` compile.
+- `unknown` is the top type: everything is assignable to it, and it is assignable only to
+  `any` and `unknown`.
+- `never` is the bottom type: it is assignable to everything, and nothing but `never` is
+  assignable to it.
+- `void` is not special to the relation and is answered structurally.
+
+Before / after:
+
+```ts
+type R = CanAssign<any, number> // was false,  now true    <- #349
+type R = CanAssign<never, any> // was never,  now true
+type R = CanAssign<never, number> // was never,  now true
+type R = CanAssign<never, unknown> // was never,  now true
+type R = CanAssign<never, never> // was never,  now true
+
+type R = StrictCanAssign<unknown, number> // was true,   now false
+type R = Assignable<unknown, 1> // was true,   now false
+type R = NotAssignable<unknown, 1> // was false,  now true
+
+type R = Assignable<1, void> // was true,   now false
+type R = Assignable<void, 1> // was true,   now false
+type R = NotAssignable<undefined, void> // was true,   now false
+```
+
+`Assignable` and `NotAssignable` had no `$void` branch at all, so a `void` on either side fell
+through `$Special` to an unconditional `$then`. That is why the two of them, which are supposed to
+be complements, both answered `true` for `<1, void>` and both answered `true` for `<undefined, void>`.
+
+Unchanged: distribution over unions (`CanAssign<number | string, number>` is still `boolean`),
+the `boolean` special case (`CanAssign<boolean, false>` is still `false`), the `$any` / `$unknown`
+/ `$never` branch overrides, and `Assignable.$` / `IsExtend`, which remain the raw
+`A extends B` forms for anyone who wants the unadorned behavior.
+
+Closes [#349](https://github.com/unional/type-plus/issues/349).

--- a/apps/website/src/content/docs/api/type-guards-and-assertions.md
+++ b/apps/website/src/content/docs/api/type-guards-and-assertions.md
@@ -123,6 +123,21 @@ type R5 = Assignable<string | number, number> // boolean (distributed)
 type R6 = Assignable<string | number, number, { distributive: false }> // false
 ```
 
+The special types follow TypeScript's own assignability relation. `any` is assignable to every type
+except `never`, and every type is assignable to `any` — so the relation is symmetric for `any`, just
+as it is in the compiler. `unknown` is the top type: everything is assignable to it, and it is
+assignable only to `any` and `unknown`. `never` is the bottom type: it is assignable to everything,
+and nothing but `never` is assignable to it. `void` is not special here and is answered structurally.
+
+```ts
+type R7 = Assignable<any, number> // true
+type R8 = Assignable<number, any> // true
+type R9 = Assignable<any, never> // false
+type R10 = Assignable<unknown, number> // false
+type R11 = Assignable<never, number> // true
+type R12 = Assignable<undefined, void> // true
+```
+
 `Assignable.$<A, B, $O>` is the inner logic without the special-type checks, for building your own types.
 
 ## IsLiteral

--- a/packages/type-plus/readme.md
+++ b/packages/type-plus/readme.md
@@ -320,6 +320,18 @@ assertType.isFalse(false as CanAssign<boolean, { a: string }>)
 assertType.isTrue(true as CanAssign<{ a:string, b:number }, { a: string }>)
 ```
 
+`any`, `unknown` and `never` follow TypeScript's own assignability relation:
+`any` is assignable to everything but `never` and everything is assignable to `any`,
+`unknown` is assignable only to `any` and `unknown`,
+and `never` is assignable to everything.
+
+```ts
+assertType.isTrue(true as CanAssign<any, number>)
+assertType.isTrue(true as CanAssign<number, any>)
+assertType.isFalse(false as CanAssign<unknown, number>)
+assertType.isTrue(true as CanAssign<never, number>)
+```
+
 > `StrictCanAssign<A, B, Then = true, Else = false>`
 
 ⭕ `predicate`: can `A` strictly assign to `B`

--- a/packages/type-plus/src/predicates/CanAssign.spec.ts
+++ b/packages/type-plus/src/predicates/CanAssign.spec.ts
@@ -31,6 +31,58 @@ describe('CanAssign<A, B>', () => {
 
 	it('distributes union types to return boolean if only part of the union is assignable', () => {
 		testType.strictBoolean<CanAssign<number | string, number>>(true)
+		testType.equal<CanAssign<number | string, number>, boolean>(true)
+	})
+
+	it('is symmetric for `any`: it assigns to everything but `never`, and everything assigns to it', () => {
+		testType.equal<CanAssign<any, number>, true>(true)
+		testType.equal<CanAssign<number, any>, true>(true)
+		testType.equal<CanAssign<any, never>, false>(true)
+
+		testType.equal<CanAssign<any, any>, true>(true)
+		testType.equal<CanAssign<any, unknown>, true>(true)
+		testType.equal<CanAssign<unknown, any>, true>(true)
+		testType.equal<CanAssign<never, any>, true>(true)
+		testType.equal<CanAssign<any, { a: 1 }>, true>(true)
+		testType.equal<CanAssign<{ a: 1 }, any>, true>(true)
+	})
+
+	it('treats `unknown` as the top type: everything assigns to it, it assigns only to `any` and `unknown`', () => {
+		testType.equal<CanAssign<number, unknown>, true>(true)
+		testType.equal<CanAssign<unknown, number>, false>(true)
+
+		testType.equal<CanAssign<unknown, unknown>, true>(true)
+		testType.equal<CanAssign<unknown, any>, true>(true)
+		testType.equal<CanAssign<unknown, never>, false>(true)
+		testType.equal<CanAssign<never, unknown>, true>(true)
+	})
+
+	it('treats `never` as the bottom type: it assigns to everything, only `never` assigns to it', () => {
+		testType.equal<CanAssign<never, number>, true>(true)
+		testType.equal<CanAssign<number, never>, false>(true)
+		testType.equal<CanAssign<never, never>, true>(true)
+
+		testType.equal<CanAssign<never, any>, true>(true)
+		testType.equal<CanAssign<never, unknown>, true>(true)
+		testType.equal<CanAssign<any, never>, false>(true)
+		testType.equal<CanAssign<unknown, never>, false>(true)
+	})
+
+	it('treats `void` as an ordinary type', () => {
+		testType.equal<CanAssign<undefined, void>, true>(true)
+		testType.equal<CanAssign<number, void>, false>(true)
+		testType.equal<CanAssign<void, void>, true>(true)
+		testType.equal<CanAssign<void, undefined>, false>(true)
+		testType.equal<CanAssign<void, number>, false>(true)
+	})
+
+	it('supports custom `Then` and `Else` for the special types', () => {
+		testType.equal<CanAssign<any, number, 'y', 'n'>, 'y'>(true)
+		testType.equal<CanAssign<unknown, number, 'y', 'n'>, 'n'>(true)
+		testType.equal<CanAssign<never, number, 'y', 'n'>, 'y'>(true)
+		testType.equal<CanAssign<number, never, 'y', 'n'>, 'n'>(true)
+		testType.equal<CanAssign<number, any, 'y', 'n'>, 'y'>(true)
+		testType.equal<CanAssign<number, unknown, 'y', 'n'>, 'y'>(true)
 	})
 })
 
@@ -39,6 +91,13 @@ describe('IsAssign<A, B>', () => {
 		testType.equal<IsAssign<1, number>, true>(true)
 		testType.equal<IsAssign<boolean, boolean>, true>(true)
 		testType.equal<IsAssign<number | string, number>, boolean>(true)
+	})
+
+	it('handles the special types the same way', () => {
+		testType.equal<IsAssign<any, number>, true>(true)
+		testType.equal<IsAssign<number, any>, true>(true)
+		testType.equal<IsAssign<unknown, number>, false>(true)
+		testType.equal<IsAssign<never, number>, true>(true)
 	})
 })
 

--- a/packages/type-plus/src/predicates/CanAssign.ts
+++ b/packages/type-plus/src/predicates/CanAssign.ts
@@ -14,7 +14,7 @@ import type { NotExtendable } from './Extends.js'
  *
  * @example
  * ```ts
- * CanAssign<number | string, number> // boolean
+ * type R = CanAssign<number | string, number> // boolean
  * ```
  *
  * We are checking can `A` assign to `B`.
@@ -25,14 +25,73 @@ import type { NotExtendable } from './Extends.js'
  *
  * If you want to make sure all branches are assignable,
  * use `StrictCanAssign<A, B>`.
+ *
+ * ## Special types
+ *
+ * `any`, `unknown` and `never` are answered by TypeScript's own assignability
+ * relation rather than by `A extends B`, which gets all three wrong.
+ *
+ * `any` is assignable to every type except `never`, and every type is
+ * assignable to `any`. So the relation is symmetric for `any` -- exactly as it
+ * is in TypeScript, where both `const b: number = a` and `const c: any = n`
+ * compile.
+ *
+ * @example
+ * ```ts
+ * type R = CanAssign<any, number> // true
+ * type R = CanAssign<number, any> // true
+ * type R = CanAssign<any, never> // false
+ * ```
+ *
+ * `unknown` is the top type: everything is assignable to it, and it is
+ * assignable only to `any` and `unknown`. The relation is *not* symmetric.
+ *
+ * @example
+ * ```ts
+ * type R = CanAssign<number, unknown> // true
+ * type R = CanAssign<unknown, number> // false
+ * ```
+ *
+ * `never` is the bottom type: it is assignable to everything, and nothing but
+ * `never` is assignable to it.
+ *
+ * @example
+ * ```ts
+ * type R = CanAssign<never, number> // true
+ * type R = CanAssign<number, never> // false
+ * type R = CanAssign<never, never> // true
+ * ```
+ *
+ * `void` is not special here -- it is answered structurally like any other
+ * type.
+ *
+ * @example
+ * ```ts
+ * type R = CanAssign<undefined, void> // true
+ * type R = CanAssign<number, void> // false
+ * ```
  */
-export type CanAssign<A, B, Then = true, Else = false> = boolean extends A
-	? boolean extends B
+export type CanAssign<A, B, Then = true, Else = false> = 0 extends 1 & B
+	? Then
+	: [B, unknown] extends [unknown, B]
 		? Then
-		: Else
-	: A extends B
-		? Then
-		: Else
+		: [B, never] extends [never, B]
+			? [A, never] extends [never, A]
+				? Then
+				: Else
+			: 0 extends 1 & A
+				? Then
+				: [A, unknown] extends [unknown, A]
+					? Else
+					: [A, never] extends [never, A]
+						? Then
+						: boolean extends A
+							? boolean extends B
+								? Then
+								: Else
+							: A extends B
+								? Then
+								: Else
 
 /**
  * Can `A` strictly assign to `B`.
@@ -41,10 +100,20 @@ export type CanAssign<A, B, Then = true, Else = false> = boolean extends A
  *
  * @deprecated use `Assignable<A, B, { distributive: false }>` instead
  *
+ * The special types follow the same rules as `CanAssign`: `any` is assignable
+ * to everything but `never` and everything is assignable to `any`, `unknown`
+ * is assignable only to `any` and `unknown`, and `never` is assignable to
+ * everything.
+ *
  * @example
  * ```ts
- * StrictCanAssign<number | string, number> // false
- * StrictCanAssign<number | string, number | string> // true
+ * type R = StrictCanAssign<number | string, number> // false
+ * type R = StrictCanAssign<number | string, number | string> // true
+ *
+ * type R = StrictCanAssign<any, number> // true
+ * type R = StrictCanAssign<number, any> // true
+ * type R = StrictCanAssign<unknown, number> // false
+ * type R = StrictCanAssign<never, number> // true
  * ```
  */
 export type StrictCanAssign<A, B, Then = true, Else = false> = Assignable<
@@ -69,6 +138,11 @@ export type StrictCanAssign<A, B, Then = true, Else = false> = Assignable<
  * type R = IsAssign<boolean, boolean> // true
  *
  * type R = IsAssign<number | string, number> // boolean
+ *
+ * type R = IsAssign<any, number> // true
+ * type R = IsAssign<number, any> // true
+ * type R = IsAssign<unknown, number> // false
+ * type R = IsAssign<never, number> // true
  * ```
  */
 export type IsAssign<A, B, Then = true, Else = false> = CanAssign<A, B, Then, Else>

--- a/packages/type-plus/src/predicates/assignability.strict.spec.ts
+++ b/packages/type-plus/src/predicates/assignability.strict.spec.ts
@@ -35,4 +35,33 @@ describe('StrictCanAssign<A, B>', () => {
 
 		testType.false<StrictCanAssign<number | string, number>>(true)
 	})
+
+	it('follows TypeScript for the special types', () => {
+		// `any` assigns to everything but `never`, and everything assigns to `any`.
+		testType.equal<StrictCanAssign<any, number>, true>(true)
+		testType.equal<StrictCanAssign<number, any>, true>(true)
+		testType.equal<StrictCanAssign<any, never>, false>(true)
+
+		// `unknown` is the top type.
+		testType.equal<StrictCanAssign<number, unknown>, true>(true)
+		testType.equal<StrictCanAssign<unknown, number>, false>(true)
+		testType.equal<StrictCanAssign<unknown, never>, false>(true)
+
+		// `never` is the bottom type.
+		testType.equal<StrictCanAssign<never, number>, true>(true)
+		testType.equal<StrictCanAssign<number, never>, false>(true)
+		testType.equal<StrictCanAssign<never, never>, true>(true)
+
+		testType.equal<StrictCanAssign<any, any>, true>(true)
+		testType.equal<StrictCanAssign<unknown, unknown>, true>(true)
+		testType.equal<StrictCanAssign<never, any>, true>(true)
+		testType.equal<StrictCanAssign<never, unknown>, true>(true)
+	})
+
+	it('treats `void` as an ordinary type', () => {
+		testType.equal<StrictCanAssign<undefined, void>, true>(true)
+		testType.equal<StrictCanAssign<number, void>, false>(true)
+		testType.equal<StrictCanAssign<void, void>, true>(true)
+		testType.equal<StrictCanAssign<void, undefined>, false>(true)
+	})
 })

--- a/packages/type-plus/src/predicates/assignable.spec.ts
+++ b/packages/type-plus/src/predicates/assignable.spec.ts
@@ -51,10 +51,28 @@ it('returns false when B is `never` except when A is `never`', () => {
 	testType.false<Assignable<undefined, never>>(true)
 })
 
-it('works against special types', () => {
+it('follows TypeScript for special types on the `A` side', () => {
+	// `any` is assignable to everything but `never`.
 	testType.equal<Assignable<any, 1>, true>(true)
-	testType.equal<Assignable<unknown, 1>, true>(true)
+	// `unknown` is assignable only to `any` and `unknown`.
+	testType.equal<Assignable<unknown, 1>, false>(true)
+	// `never` is the bottom type, so it is assignable to everything.
 	testType.equal<Assignable<never, 1>, true>(true)
+})
+
+it('treats `void` as an ordinary type on either side', () => {
+	testType.equal<Assignable<undefined, void>, true>(true)
+	testType.equal<Assignable<1, void>, false>(true)
+	testType.equal<Assignable<void, void>, true>(true)
+	testType.equal<Assignable<void, 1>, false>(true)
+	testType.equal<Assignable<void, undefined>, false>(true)
+
+	testType.equal<Assignable<any, void>, true>(true)
+	testType.equal<Assignable<unknown, void>, false>(true)
+	testType.equal<Assignable<never, void>, true>(true)
+	testType.equal<Assignable<void, any>, true>(true)
+	testType.equal<Assignable<void, unknown>, true>(true)
+	testType.equal<Assignable<void, never>, false>(true)
 })
 
 it('can disable distribution', () => {

--- a/packages/type-plus/src/predicates/assignable.ts
+++ b/packages/type-plus/src/predicates/assignable.ts
@@ -24,6 +24,29 @@ import type { $Unknown } from '../$type/special/$unknown.js'
  * type R = Assignable<'a', string> // true
  * ```
  *
+ * The special types follow TypeScript's own assignability relation:
+ *
+ * - `any` is assignable to every type except `never`,
+ *   and every type is assignable to `any`.
+ * - `unknown` is the top type: everything is assignable to it,
+ *   and it is assignable only to `any` and `unknown`.
+ * - `never` is the bottom type: it is assignable to everything,
+ *   and nothing but `never` is assignable to it.
+ * - `void` is not special here and is answered structurally.
+ *
+ * @example
+ * ```ts
+ * type R = Assignable<any, number> // true
+ * type R = Assignable<number, any> // true
+ * type R = Assignable<any, never> // false
+ * type R = Assignable<unknown, number> // false
+ * type R = Assignable<number, unknown> // true
+ * type R = Assignable<never, number> // true
+ * type R = Assignable<number, never> // false
+ * type R = Assignable<undefined, void> // true
+ * type R = Assignable<number, void> // false
+ * ```
+ *
  * 🔢 *customize*
  *
  * Filter to ensure `A` is assignable to `B`.
@@ -60,15 +83,25 @@ export type Assignable<A, B, $O extends Assignable.$Options = {}> = $Special<
 		$any: $ResolveBranch<$O, [0 extends 1 & A ? $Any : unknown, $Then], A>
 		$unknown: $ResolveBranch<$O, [[A, unknown] extends [unknown, A] ? $Unknown : unknown, $Then], A>
 		$never: $ResolveBranch<$O, [A, never] extends [never, A] ? [$Never, $Then] : [$Else], A>
-		$else: $Special<
-			A,
-			{
-				$any: $ResolveBranch<$O, [$Any, $Then], A>
-				$unknown: $ResolveBranch<$O, [$Unknown, $Then], A>
-				$never: $ResolveBranch<$O, [$Never, $Then], A>
-				$else: Assignable.$<A, B, $O>
-			}
-		>
+		$void: _AssignableToOrdinary<A, B, $O>
+		$else: _AssignableToOrdinary<A, B, $O>
+	}
+>
+
+/**
+ * `Assignable` with `B` already known not to be `any`, `unknown` or `never`.
+ *
+ * `void` shares this branch: it is only special to `$Special`, not to the
+ * assignability relation, so it is answered structurally like any other type.
+ */
+type _AssignableToOrdinary<A, B, $O extends Assignable.$Options> = $Special<
+	A,
+	{
+		$any: $ResolveBranch<$O, [$Any, $Then], A>
+		$unknown: $ResolveBranch<$O, [$Unknown, $Else], A>
+		$never: $ResolveBranch<$O, [$Never, $Then], A>
+		$void: Assignable.$<A, B, $O>
+		$else: Assignable.$<A, B, $O>
 	}
 >
 

--- a/packages/type-plus/src/predicates/not_assignable.spec.ts
+++ b/packages/type-plus/src/predicates/not_assignable.spec.ts
@@ -51,10 +51,28 @@ it('returns false when B is `never` except when A is `never`', () => {
 	testType.true<NotAssignable<undefined, never>>(true)
 })
 
-it('works against special types', () => {
+it('follows TypeScript for special types on the `A` side', () => {
+	// `any` is assignable to everything but `never`.
 	testType.equal<NotAssignable<any, 1>, false>(true)
-	testType.equal<NotAssignable<unknown, 1>, false>(true)
+	// `unknown` is assignable only to `any` and `unknown`.
+	testType.equal<NotAssignable<unknown, 1>, true>(true)
+	// `never` is the bottom type, so it is assignable to everything.
 	testType.equal<NotAssignable<never, 1>, false>(true)
+})
+
+it('treats `void` as an ordinary type on either side', () => {
+	testType.equal<NotAssignable<undefined, void>, false>(true)
+	testType.equal<NotAssignable<1, void>, true>(true)
+	testType.equal<NotAssignable<void, void>, false>(true)
+	testType.equal<NotAssignable<void, 1>, true>(true)
+	testType.equal<NotAssignable<void, undefined>, true>(true)
+
+	testType.equal<NotAssignable<any, void>, false>(true)
+	testType.equal<NotAssignable<unknown, void>, true>(true)
+	testType.equal<NotAssignable<never, void>, false>(true)
+	testType.equal<NotAssignable<void, any>, false>(true)
+	testType.equal<NotAssignable<void, unknown>, false>(true)
+	testType.equal<NotAssignable<void, never>, true>(true)
 })
 
 it('can disable distribution', () => {

--- a/packages/type-plus/src/predicates/not_assignable.ts
+++ b/packages/type-plus/src/predicates/not_assignable.ts
@@ -24,6 +24,29 @@ import type { $Unknown } from '../$type/special/$unknown.js'
  * type R = NotAssignable<'a', string> // false
  * ```
  *
+ * The special types follow TypeScript's own assignability relation:
+ *
+ * - `any` is assignable to every type except `never`,
+ *   and every type is assignable to `any`.
+ * - `unknown` is the top type: everything is assignable to it,
+ *   and it is assignable only to `any` and `unknown`.
+ * - `never` is the bottom type: it is assignable to everything,
+ *   and nothing but `never` is assignable to it.
+ * - `void` is not special here and is answered structurally.
+ *
+ * @example
+ * ```ts
+ * type R = NotAssignable<any, number> // false
+ * type R = NotAssignable<number, any> // false
+ * type R = NotAssignable<any, never> // true
+ * type R = NotAssignable<unknown, number> // true
+ * type R = NotAssignable<number, unknown> // false
+ * type R = NotAssignable<never, number> // false
+ * type R = NotAssignable<number, never> // true
+ * type R = NotAssignable<undefined, void> // false
+ * type R = NotAssignable<number, void> // true
+ * ```
+ *
  * 🔢 *customize*
  *
  * Filter to ensure `A` is not assignable to `B`.
@@ -60,15 +83,25 @@ export type NotAssignable<A, B, $O extends NotAssignable.$Options = {}> = $Speci
 		$any: $ResolveBranch<$O, [0 extends 1 & A ? $Any : unknown, $Else], A>
 		$unknown: $ResolveBranch<$O, [[A, unknown] extends [unknown, A] ? $Unknown : unknown, $Else], A>
 		$never: $ResolveBranch<$O, [A, never] extends [never, A] ? [$Never, $Else] : [$Then], A>
-		$else: $Special<
-			A,
-			{
-				$any: $ResolveBranch<$O, [$Any, $Else], A>
-				$unknown: $ResolveBranch<$O, [$Unknown, $Else], A>
-				$never: $ResolveBranch<$O, [$Never, $Else], A>
-				$else: NotAssignable.$<A, B, $O>
-			}
-		>
+		$void: _NotAssignableToOrdinary<A, B, $O>
+		$else: _NotAssignableToOrdinary<A, B, $O>
+	}
+>
+
+/**
+ * `NotAssignable` with `B` already known not to be `any`, `unknown` or `never`.
+ *
+ * `void` shares this branch: it is only special to `$Special`, not to the
+ * assignability relation, so it is answered structurally like any other type.
+ */
+type _NotAssignableToOrdinary<A, B, $O extends NotAssignable.$Options> = $Special<
+	A,
+	{
+		$any: $ResolveBranch<$O, [$Any, $Else], A>
+		$unknown: $ResolveBranch<$O, [$Unknown, $Then], A>
+		$never: $ResolveBranch<$O, [$Never, $Else], A>
+		$void: NotAssignable.$<A, B, $O>
+		$else: NotAssignable.$<A, B, $O>
 	}
 >
 


### PR DESCRIPTION
Closes #349.

## The report

`assertType.isTrue(true as CanAssign<any, number>)` does not compile, but reversing the arguments does. In TypeScript the relation is symmetric for `any` — both of these compile:

```ts
let a: any = 4
let b: number = a

let d: number = 3
let e: any = d
```

## What was actually happening

`CanAssign<A, B>` was a bare `A extends B` behind a `boolean extends A` guard. `extends` is not assignability, and the guard made it worse:

| | before | TypeScript |
|---|---|---|
| `CanAssign<any, number>` | `false` — `boolean extends any` is true, so it fell into the guard and compared `boolean extends number` | `true` |
| `CanAssign<never, number>` | `never` — `A extends B` distributes over the empty union | `true` |
| `CanAssign<never, any>` / `<never, unknown>` / `<never, never>` | `never` | `true` |

While establishing the table for `unknown` and `never` on both sides (as the brief asked), two more defects surfaced in the modern types that `CanAssign` is deprecated in favour of:

- `Assignable` short-circuited `unknown` on the `A` side to `$then`, so `Assignable<unknown, 1>` and `StrictCanAssign<unknown, number>` were `true`. `unknown` is assignable only to `any` and `unknown`.
- `Assignable` and `NotAssignable` had **no `$void` branch at all**. A `void` on either side fell through `$Special` to an unconditional `$then`, so `Assignable<1, void>` and `NotAssignable<1, void>` were *both* `true` — two types that are supposed to be complements agreeing.

## The judgment call

The library models TypeScript's real assignability relation rather than departing from it, and `CanAssign`'s own docs claim to answer "can `A` assign to `B`".

The house convention supports this. `IsNumber<any>` is `false`, `IsNumber<unknown>` is `false`, `IsNumber<never>` is `false` — predicates answer the *semantically correct* thing for the special types and expose `$any` / `$unknown` / `$never` overrides for callers who want something else. They do not blanket-route specials to `$then`. `Assignable`'s A-side table was the outlier, and its missing `$void` branch shows that table was never fully reviewed.

Anyone who wants unadorned `A extends B` still has `IsExtend` and `Assignable.$`, which are documented as exactly that and are unchanged.

So the rule, now applied uniformly across `CanAssign`, `IsAssign`, `StrictCanAssign`, `Assignable` and `NotAssignable`:

- `any` is assignable to every type except `never`, and every type is assignable to `any` — **symmetric**, as in the compiler.
- `unknown` is the top type: everything is assignable to it; it is assignable only to `any` and `unknown`.
- `never` is the bottom type: assignable to everything; nothing but `never` is assignable to it.
- `void` is not special to the relation and is answered structurally.

Verified against `tsc` directly, including the two easy-to-get-wrong corners: `any` is *not* assignable to `never`, and `unknown` is *not* assignable to `never`.

## Breaking changes

Filed as a **major** changeset with the before/after table, so it reaches the v8 beta release notes.

```ts
type R = CanAssign<any, number>            // was false,  now true    <- #349
type R = CanAssign<never, number>          // was never,  now true
type R = StrictCanAssign<unknown, number>  // was true,   now false
type R = Assignable<unknown, 1>            // was true,   now false
type R = NotAssignable<unknown, 1>         // was false,  now true
type R = Assignable<1, void>               // was true,   now false
type R = Assignable<void, 1>               // was true,   now false
type R = NotAssignable<undefined, void>    // was true,   now false
```

Unchanged: union distribution (`CanAssign<number | string, number>` is still `boolean`), the `boolean` special case (`CanAssign<boolean, false>` is still `false`), all branch overrides, and `Assignable.$` / `IsExtend`.

## Verification

- `pnpm verify` green.
- `pnpm --filter type-plus test:type` green on **all five** TS versions — 5.4, 5.5, 5.6, 6.0 and 7, each run individually, none skipped.
- New specs cover `any` / `unknown` / `never` / `void` on both sides for `CanAssign`, `IsAssign`, `StrictCanAssign`, `Assignable` and `NotAssignable`, plus custom `Then`/`Else` for the special branches. Every new TSDoc `@example` is pinned by a `testType.equal` in the spec for the symbol it documents.
- Docs updated in all three homes: TSDoc, `apps/website/src/content/docs/api/type-guards-and-assertions.md`, and the `packages/type-plus/readme.md` entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
